### PR TITLE
Add FAQ content to About page

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -154,25 +154,175 @@
     "removed": "Produkt aus dem Warenkorb entfernt!"
   },
   "about": {
-    "title": "Adrienn Pál",
-    "intro1": "Adrienn Pál setzt sich dafür ein, die heilende Kraft des Klangs für alle zugänglich zu machen. Willkommen im Klangakademie-Webshop! Mein Ziel ist es, die heilende, harmonisierende Kraft von Klängen und Schwingungen für alle zugänglich zu machen.",
-    "intro2": "Die hier erhältlichen Klangschalen, Gongs, Stimmgabeln und besonderen Instrumente dienen alle dem Gleichgewicht von Körper und Seele – sei es zur Entspannung, Meditation, Therapie oder einfach zur täglichen inneren Harmonie.\nZu jedem Instrument erhalten Sie fachkundige Beratung, detaillierte Beschreibungen und praktische Anleitung, wenn Sie möchten. Sie können mehr über die Instrumente lernen und bei meinen Schulungen üben – denn ich glaube, dass Klang nicht nur erklingt, sondern lehrt, heilt und verbindet.",
-    "imageAlt": "Porträt von Adrienn Pál",
-    "mission": "Warum uns wählen?",
-    "missionText": "Sorgfältig ausgewählte, hochwertige Instrumente\nEinzigartige Klangschalen-Beschreibungen (Frequenz, Klang, Chakra-Verbindung) – ein besonderer Service nur hier\nFachkundige Anleitung und Bildungsangebot\nSchneller, sicherer Versand.",
-    "faq": "Häufig gestellte Fragen",
-    "faqItems": {
-      "soundHealing": "Was ist Klangtherapie?",
-      "chooseInstrument": "Wie wähle ich das richtige Instrument?",
-      "workshops": "Bieten Sie Workshops an?",
-      "benefits": "Welche Vorteile bietet Klangtherapie?"
-    },
-    "faqAnswers": {
-      "soundHealing": "Klangtherapie ist eine Methode, die die Schwingungen von Instrumenten nutzt, um das körperliche und geistige Wohlbefinden zu fördern.",
-      "chooseInstrument": "Absicht und persönliche Vorlieben sind wichtig. Wir helfen Ihnen gerne, das perfekte Instrument zu finden.",
-      "workshops": "Ja, wir bieten Workshops für alle Niveaus an. Schauen Sie in unseren Veranstaltungen nach Details.",
-      "benefits": "Klangtherapie kann helfen, Stress zu reduzieren, die Konzentration zu verbessern und die Gesundheit zu fördern."
-    }
+    "title": "A HangAkadémia® – ahol a hang tudássá válik",
+    "imageAlt": "A HangAkadémia® alapítója",
+    "introParagraphs": [
+      "A HangAkadémia® egy strukturált szakmai szemlélet mentén működő webshop, amelynek kínálata következetes szakmai szűrés és tapasztalati alapú válogatás eredménye.",
+      "A hangszerek itt nem pusztán termékek, hanem olyan eszközök, amelyek hangzásukban, karakterükben és funkcionális alkalmazhatóságukban is megfelelnek a képviselt szakmai elveknek."
+    ],
+    "sections": [
+      {
+        "title": "A HangAkadémia® célja",
+        "paragraphs": [
+          "A HangAkadémia® célja, hogy világos, megbízható és szakmailag értelmezhető választási keretet biztosítson mindazok számára, akik a hangszerekkel való munkát tudatos döntésekre, felelősségvállalásra és hosszú távú szemléletre alapozzák – legyen szó személyes használatról, oktatási környezetről vagy professzionális gyakorlatról."
+        ]
+      },
+      {
+        "title": "Pál Adrienn– alapító, szakmai vezető",
+        "paragraphs": [
+          "Pál Adrienn a HangAkadémia® alapítója és szakmai vezetője.",
+          "Munkájának középpontjában a hangtálak, hangvillák, gongok és egyéb rezgésalapú hangszerek tudatos, felelős és szakmailag megalapozott alkalmazása áll."
+        ],
+        "listTitle": "Számára kiemelten fontos, hogy minden hangszer:",
+        "listItems": [
+          "minőségében ellenőrzött legyen",
+          "hangzásában tiszta és kiegyensúlyozott",
+          "rezgéskarakterében következetes",
+          "és valódi szakmai értéket képviseljen"
+        ],
+        "closingParagraph": "A HangAkadémia® webshop kínálata ennek a szemléletnek az eredménye: minden hangszer személyes válogatáson és szakmai szűrésen megy keresztül."
+      },
+      {
+        "title": "Hivatalos szakmai háttér",
+        "paragraphs": [
+          "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere.",
+          "Pál Adriennl Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete, közvetlen kapcsolatban a gyártó nemzetközi csapatával."
+        ],
+        "listTitle": "Ez a szakmai együttműködés biztosítja, hogy a webshopban:",
+        "listItems": [
+          "kizárólag eredeti, ellenőrzött forrásból származó hangszerek jelenjenek meg",
+          "naprakész termékkínálat legyen elérhető",
+          "hiteles, szakmailag megalapozott információk álljanak a vásárlók rendelkezésére"
+        ]
+      },
+      {
+        "title": "Miért válaszd a HangAkadémiát?",
+        "features": [
+          {
+            "title": "Személyesen válogatott hangszerek",
+            "description": "Minden hangszer gondos kiválasztás eredménye. A hang tisztasága, a rezgés minősége és az anyaghasználat alapvető szempont a kínálat összeállításakor."
+          },
+          {
+            "title": "Szakértői útmutatás",
+            "description": "A HangAkadémiánál® nem csupán vásárolsz. Segítünk eligazodni a hangmagasságok, frekvenciák, méretek és hangkarakterek között, hogy valóban a hozzád illő hangszer kerüljön hozzád."
+          },
+          {
+            "title": "Oktatási háttér",
+            "description": "A Hangakadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
+          },
+          {
+            "title": "Prémium minőség és biztonság",
+            "description": "A hangszereket gondosan csomagolva, fokozott figyelemmel juttatjuk el hozzád, hogy a minőség már az első megszólaláskor érezhető legyen."
+          }
+        ]
+      },
+      {
+        "title": "A Hangakadémia® szemlélete",
+        "paragraphs": [
+          "A HangAkadémiánál® a hang egyszerre élmény és minőség.",
+          "Lehet önfeledt, lehet elmélyítő, lehet inspiráló – számunkra azonban mindig fontos, hogyan szólal meg, milyen minőséget képvisel, és milyen kapcsolatot teremt az ember és a hangszer között.",
+          "Minden hangszer, amely a kínálatunkba kerül, ezt a szemléletet tükrözi: tudatos választás, tiszta hangzás és szakmai megbízhatóság."
+        ]
+      }
+    ],
+    "faqTitle": "GYIK",
+    "faqItems": [
+      {
+        "question": "Mi az a hangterápia / hangalapú hangmunka?",
+        "answerParagraphs": [
+          "A hangterápia a hang és a rezgés tudatos alkalmazásán alapuló megközelítés, amely különböző hangszerek segítségével a hallás, az észlelés és a figyelem folyamatára épül.",
+          "A gyakorlat középpontjában nem diagnózis vagy gyógyítás áll, hanem a hangélmény strukturált, célzott használata egyéni vagy csoportos környezetben."
+        ]
+      },
+      {
+        "question": "Milyen célra használhatók a webshopban kapható hangszerek?",
+        "answerParagraphs": ["A HangAkadémia® kínálatában szereplő hangszerek használhatók:"],
+        "listItems": [
+          "otthoni relaxációra",
+          "meditációs vagy figyelem fókuszáló gyakorlatokhoz",
+          "oktatási környezetben",
+          "professzionális hangmunkához (pl. hangfürdők, csoportos hangélmények)"
+        ],
+        "closing": "A hangszerek nem minősülnek orvosi vagy terápiás eszköznek."
+      },
+      {
+        "question": "Hogyan válasszam ki a számomra megfelelő hangszert?",
+        "answerParagraphs": ["A megfelelő hangszer kiválasztása több tényezőtől függ, például:"],
+        "listItems": [
+          "milyen célra szeretnéd használni",
+          "milyen hangmagasság vagy hangkarakter áll közel hozzád",
+          "otthoni vagy professzionális környezetben alkalmazod-e"
+        ],
+        "closing": "Ha bizonytalan vagy, lehetőséget biztosítunk személyre szabott szakmai ajánlásra, amely segít eligazodni a kínálatban."
+      },
+      {
+        "question": "Miben különbözik a HangAkadémia® webshop más hangszer webshopoktól?",
+        "answerParagraphs": [
+          "A HangAkadémia® kínálata nem tömeges termékkatalógus.",
+          "Minden hangszer szakmai szempontok szerint válogatott, személyes tapasztalaton és következetes szemléleten alapul.",
+          "A webshop mögött aktív oktatási és szakmai háttér áll, amely biztosítja a hiteles tájékoztatást és az egységes minőségi szemléletet."
+        ]
+      },
+      {
+        "question": "Kapok segítséget a hangszerek használatához?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® célja, hogy a vásárlók ne csak hangszert kapjanak, hanem érthető szakmai útmutatást is."
+        ],
+        "listItems": [
+          "termékleírásokon keresztül",
+          "egyedi ajánlás formájában",
+          "oktatási anyagokon és képzéseken keresztül"
+        ]
+      },
+      {
+        "question": "Tartotok képzéseket, workshopokat?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® oktatási tevékenysége keretében online és személyes képzéseket is kínál, strukturált rendszerben, különböző szinteken."
+        ],
+        "closing": "Az aktuális képzések és események mindig a hivatalos felületekeinken érhetők el.",
+        "linkText": "Oktatások megtekintése",
+        "linkUrl": "https://hangakademia.hu/oktatasok.html"
+      },
+      {
+        "question": "A hangszerek rendelkeznek egészségügyi vagy gyógyászati hatással?",
+        "answerParagraphs": [
+          "A webshopban kapható hangszerek nem egészségügyi eszközök, és nem helyettesítenek orvosi vagy terápiás kezeléseket.",
+          "A hangszerek használata élményalapú, oktatási és kreatív célokat szolgál."
+        ]
+      },
+      {
+        "question": "Kezdők is vásárolhatnak a webshopból?",
+        "answerParagraphs": [
+          "Igen.",
+          "A kínálat összeállításakor figyelünk arra, hogy kezdők számára is jól használható hangszerek elérhetők legyenek, megfelelő szakmai magyarázattal és ajánlással."
+        ]
+      },
+      {
+        "question": "Professzionális felhasználók számára is megfelelőek a hangszerek?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® kínálata alkalmas professzionális hangmunkára is, például:"
+        ],
+        "listItems": [
+          "csoportos hangélményekhez",
+          "oktatáshoz",
+          "különböző hangfürdők lebonyolításához"
+        ],
+        "closing": "A választásnál azonban fontos a megfelelő hangszer és méret kiválasztása."
+      },
+      {
+        "question": "Mit tegyek, ha nem vagyok biztos a választásomban?",
+        "answerParagraphs": [
+          "Ha bizonytalan vagy, javasoljuk, hogy vedd fel velünk a kapcsolatot.",
+          "Szívesen segítünk eligazodni a hangszerek között, és szakmai szempontok alapján ajánlunk megoldást."
+        ]
+      }
+    ],
+    "quoteLabel": "Személyes üzenet tőlem",
+    "quoteText": "„A hanggal való munka számomra figyelmet és tiszteletet jelent. Minden hangszer, amely a Hangakadémián megjelenik, ezen a szemléleten keresztül érkezik.”",
+    "quoteAuthor": "— Adrienn Pál"
   },
   "contact": {
     "title": "Kontakt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -143,25 +143,175 @@
     "addedDescription": "{{title}} has been added to your cart."
   },
   "about": {
-    "title": "Adrienn Pál",
-    "intro1": "Adrienn Pál is dedicated to bringing the healing power of sound to everyone. Welcome to the SoundAcademy webshop! My goal is to make the healing, harmonizing power of sounds and vibrations accessible to all.",
-    "intro2": "The singing bowls, gongs, tuning forks, and special instruments available here all serve the balance of body and soul—whether for relaxation, meditation, therapy, or simply creating everyday inner harmony.\nEach instrument comes with expert advice, detailed descriptions, and practical guidance if you wish. You can learn more about the instruments and practice at my trainings—because I believe sound not only resonates, but teaches, heals, and connects.",
-    "imageAlt": "Portrait of Adrienn Pál",
-    "mission": "Why choose us?",
-    "missionText": "Carefully selected, premium quality instruments\nUnique singing bowl descriptions (frequency, sound, chakra connection)—a special service only here\nExpert guidance and educational background\nFast, secure shipping.",
-    "faq": "Frequently Asked Questions",
-    "faqItems": {
-      "soundHealing": "What is sound therapy?",
-      "chooseInstrument": "How do I choose the right instrument?",
-      "workshops": "Do you offer workshops?",
-      "benefits": "What are the benefits of sound therapy?"
-    },
-    "faqAnswers": {
-      "soundHealing": "Sound therapy is a method that uses the vibrations of instruments to promote physical and mental well-being.",
-      "chooseInstrument": "Intention and personal preference are important. We are happy to help you find the perfect instrument.",
-      "workshops": "Yes, we offer workshops for all levels. Check our events for details.",
-      "benefits": "Sound therapy can help reduce stress, improve focus, and support overall health."
-    }
+    "title": "A HangAkadémia® – ahol a hang tudássá válik",
+    "imageAlt": "A HangAkadémia® alapítója",
+    "introParagraphs": [
+      "A HangAkadémia® egy strukturált szakmai szemlélet mentén működő webshop, amelynek kínálata következetes szakmai szűrés és tapasztalati alapú válogatás eredménye.",
+      "A hangszerek itt nem pusztán termékek, hanem olyan eszközök, amelyek hangzásukban, karakterükben és funkcionális alkalmazhatóságukban is megfelelnek a képviselt szakmai elveknek."
+    ],
+    "sections": [
+      {
+        "title": "A HangAkadémia® célja",
+        "paragraphs": [
+          "A HangAkadémia® célja, hogy világos, megbízható és szakmailag értelmezhető választási keretet biztosítson mindazok számára, akik a hangszerekkel való munkát tudatos döntésekre, felelősségvállalásra és hosszú távú szemléletre alapozzák – legyen szó személyes használatról, oktatási környezetről vagy professzionális gyakorlatról."
+        ]
+      },
+      {
+        "title": "Pál Adrienn– alapító, szakmai vezető",
+        "paragraphs": [
+          "Pál Adrienn a HangAkadémia® alapítója és szakmai vezetője.",
+          "Munkájának középpontjában a hangtálak, hangvillák, gongok és egyéb rezgésalapú hangszerek tudatos, felelős és szakmailag megalapozott alkalmazása áll."
+        ],
+        "listTitle": "Számára kiemelten fontos, hogy minden hangszer:",
+        "listItems": [
+          "minőségében ellenőrzött legyen",
+          "hangzásában tiszta és kiegyensúlyozott",
+          "rezgéskarakterében következetes",
+          "és valódi szakmai értéket képviseljen"
+        ],
+        "closingParagraph": "A HangAkadémia® webshop kínálata ennek a szemléletnek az eredménye: minden hangszer személyes válogatáson és szakmai szűrésen megy keresztül."
+      },
+      {
+        "title": "Hivatalos szakmai háttér",
+        "paragraphs": [
+          "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere.",
+          "Pál Adriennl Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete, közvetlen kapcsolatban a gyártó nemzetközi csapatával."
+        ],
+        "listTitle": "Ez a szakmai együttműködés biztosítja, hogy a webshopban:",
+        "listItems": [
+          "kizárólag eredeti, ellenőrzött forrásból származó hangszerek jelenjenek meg",
+          "naprakész termékkínálat legyen elérhető",
+          "hiteles, szakmailag megalapozott információk álljanak a vásárlók rendelkezésére"
+        ]
+      },
+      {
+        "title": "Miért válaszd a HangAkadémiát?",
+        "features": [
+          {
+            "title": "Személyesen válogatott hangszerek",
+            "description": "Minden hangszer gondos kiválasztás eredménye. A hang tisztasága, a rezgés minősége és az anyaghasználat alapvető szempont a kínálat összeállításakor."
+          },
+          {
+            "title": "Szakértői útmutatás",
+            "description": "A HangAkadémiánál® nem csupán vásárolsz. Segítünk eligazodni a hangmagasságok, frekvenciák, méretek és hangkarakterek között, hogy valóban a hozzád illő hangszer kerüljön hozzád."
+          },
+          {
+            "title": "Oktatási háttér",
+            "description": "A Hangakadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
+          },
+          {
+            "title": "Prémium minőség és biztonság",
+            "description": "A hangszereket gondosan csomagolva, fokozott figyelemmel juttatjuk el hozzád, hogy a minőség már az első megszólaláskor érezhető legyen."
+          }
+        ]
+      },
+      {
+        "title": "A Hangakadémia® szemlélete",
+        "paragraphs": [
+          "A HangAkadémiánál® a hang egyszerre élmény és minőség.",
+          "Lehet önfeledt, lehet elmélyítő, lehet inspiráló – számunkra azonban mindig fontos, hogyan szólal meg, milyen minőséget képvisel, és milyen kapcsolatot teremt az ember és a hangszer között.",
+          "Minden hangszer, amely a kínálatunkba kerül, ezt a szemléletet tükrözi: tudatos választás, tiszta hangzás és szakmai megbízhatóság."
+        ]
+      }
+    ],
+    "faqTitle": "GYIK",
+    "faqItems": [
+      {
+        "question": "Mi az a hangterápia / hangalapú hangmunka?",
+        "answerParagraphs": [
+          "A hangterápia a hang és a rezgés tudatos alkalmazásán alapuló megközelítés, amely különböző hangszerek segítségével a hallás, az észlelés és a figyelem folyamatára épül.",
+          "A gyakorlat középpontjában nem diagnózis vagy gyógyítás áll, hanem a hangélmény strukturált, célzott használata egyéni vagy csoportos környezetben."
+        ]
+      },
+      {
+        "question": "Milyen célra használhatók a webshopban kapható hangszerek?",
+        "answerParagraphs": ["A HangAkadémia® kínálatában szereplő hangszerek használhatók:"],
+        "listItems": [
+          "otthoni relaxációra",
+          "meditációs vagy figyelem fókuszáló gyakorlatokhoz",
+          "oktatási környezetben",
+          "professzionális hangmunkához (pl. hangfürdők, csoportos hangélmények)"
+        ],
+        "closing": "A hangszerek nem minősülnek orvosi vagy terápiás eszköznek."
+      },
+      {
+        "question": "Hogyan válasszam ki a számomra megfelelő hangszert?",
+        "answerParagraphs": ["A megfelelő hangszer kiválasztása több tényezőtől függ, például:"],
+        "listItems": [
+          "milyen célra szeretnéd használni",
+          "milyen hangmagasság vagy hangkarakter áll közel hozzád",
+          "otthoni vagy professzionális környezetben alkalmazod-e"
+        ],
+        "closing": "Ha bizonytalan vagy, lehetőséget biztosítunk személyre szabott szakmai ajánlásra, amely segít eligazodni a kínálatban."
+      },
+      {
+        "question": "Miben különbözik a HangAkadémia® webshop más hangszer webshopoktól?",
+        "answerParagraphs": [
+          "A HangAkadémia® kínálata nem tömeges termékkatalógus.",
+          "Minden hangszer szakmai szempontok szerint válogatott, személyes tapasztalaton és következetes szemléleten alapul.",
+          "A webshop mögött aktív oktatási és szakmai háttér áll, amely biztosítja a hiteles tájékoztatást és az egységes minőségi szemléletet."
+        ]
+      },
+      {
+        "question": "Kapok segítséget a hangszerek használatához?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® célja, hogy a vásárlók ne csak hangszert kapjanak, hanem érthető szakmai útmutatást is."
+        ],
+        "listItems": [
+          "termékleírásokon keresztül",
+          "egyedi ajánlás formájában",
+          "oktatási anyagokon és képzéseken keresztül"
+        ]
+      },
+      {
+        "question": "Tartotok képzéseket, workshopokat?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® oktatási tevékenysége keretében online és személyes képzéseket is kínál, strukturált rendszerben, különböző szinteken."
+        ],
+        "closing": "Az aktuális képzések és események mindig a hivatalos felületekeinken érhetők el.",
+        "linkText": "Oktatások megtekintése",
+        "linkUrl": "https://hangakademia.hu/oktatasok.html"
+      },
+      {
+        "question": "A hangszerek rendelkeznek egészségügyi vagy gyógyászati hatással?",
+        "answerParagraphs": [
+          "A webshopban kapható hangszerek nem egészségügyi eszközök, és nem helyettesítenek orvosi vagy terápiás kezeléseket.",
+          "A hangszerek használata élményalapú, oktatási és kreatív célokat szolgál."
+        ]
+      },
+      {
+        "question": "Kezdők is vásárolhatnak a webshopból?",
+        "answerParagraphs": [
+          "Igen.",
+          "A kínálat összeállításakor figyelünk arra, hogy kezdők számára is jól használható hangszerek elérhetők legyenek, megfelelő szakmai magyarázattal és ajánlással."
+        ]
+      },
+      {
+        "question": "Professzionális felhasználók számára is megfelelőek a hangszerek?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® kínálata alkalmas professzionális hangmunkára is, például:"
+        ],
+        "listItems": [
+          "csoportos hangélményekhez",
+          "oktatáshoz",
+          "különböző hangfürdők lebonyolításához"
+        ],
+        "closing": "A választásnál azonban fontos a megfelelő hangszer és méret kiválasztása."
+      },
+      {
+        "question": "Mit tegyek, ha nem vagyok biztos a választásomban?",
+        "answerParagraphs": [
+          "Ha bizonytalan vagy, javasoljuk, hogy vedd fel velünk a kapcsolatot.",
+          "Szívesen segítünk eligazodni a hangszerek között, és szakmai szempontok alapján ajánlunk megoldást."
+        ]
+      }
+    ],
+    "quoteLabel": "Személyes üzenet tőlem",
+    "quoteText": "„A hanggal való munka számomra figyelmet és tiszteletet jelent. Minden hangszer, amely a Hangakadémián megjelenik, ezen a szemléleten keresztül érkezik.”",
+    "quoteAuthor": "— Adrienn Pál"
   },
   "contact": {
     "title": "Contact",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -13,7 +13,7 @@
   "hero": {
     "title": "Hangakadémia® a hangok ereje a mindennapjaidban",
     "subtitle": "Merülj el a hangok gyógyító rezgésében.",
-    "description": "Eszközeink segítenek: megnyugodni elmélyülni tisztulni feltöltődni harmonizálni a test–lélek rendszerét.\nLegyen szó otthoni relaxációról, terápiás munkáról vagy professzionális hangkezelésről, nálunk megtalálod a fejlődésedhez szükséges hangszereket és tudást.\n\nVálogass prémium kategóriáinkból:\n\n• Himalájai hangtálak\n• Meinl Sonic Energy hangszerek\n• Kristálytálak\n• Hangvillák és frekvenciaeszközök\n• Gongok és rezgésterápiás hangszerek\n• Egyedi tálpárosítások, személyre szabott ajánlással\n• Exkluzív kiegészítők és tartozékok\n\nNálunk minden hangnak története van.",
+    "description": "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.\n\nA Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet.\nWebshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással.",
     "imageAlt": "Hangterápiás hangszerek"
   },
   "categories": {

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -494,14 +494,16 @@
       "delete": "Törlés"
     },
     "promo": {
-      "title": "Miért válassz minket?",
-      "intro": "A HangAkadémiánál® a hang több mint rezgés:kapocs önmagadhoz, a jelen pillanathoz, és ahhoz a belső harmóniához, amelyre mindannyian vágyunk.",
-      "point1": "Minőségi, válogatott hangszerek",
-      "point2": "Szakértői útmutatás és oktatás",
-      "point3": "Gyors, biztonságos szállítás",
-      "point4": "A hangszereket gondosan csomagoljuk és extra figyelemmel küldjük útnak.Lépj be a hangok világába.",
-      "outro": "Válassz most webshopunk prémium kínálatából, és találd meg azt az eszközt, amely megszólít —a rezgést, amely elindít a belső harmónia útján.",
-      "cta": "Meinl Sonic Energy Magyarországi Szakmai Nagykövet megtekintése"
+      "title": "HANGAKADÉMIA® – A hangok ereje a mindennapjaidban",
+      "intro": "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.",
+      "belief": "A Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet. Webshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással.",
+      "whyTitle": "Miért a Hangakadémia®?",
+      "benefit1": "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.",
+      "background1": "A Hangakadémia® nem csupán egy webshop.",
+      "background2": "Minden hangtálat és hangszert személyesen válogatunk, kipróbálunk és szakmai szempontok alapján ajánlunk.",
+      "partnership": "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete.",
+      "value": "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.",
+      "cta": "👉 Ismerd meg a Hangakadémiát® és a Meinl Sonic Energy Magyarországi Nagykövetét"
     }
   }
 }

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -12,8 +12,8 @@
   },
   "hero": {
     "title": "Hangakadémia® a hangok ereje a mindennapjaidban",
-     "subtitle": "Merülj el a hangok gyógyító rezgésében.",
-    "description": "Eszközeink segítenek: megnyugodni elmélyülni tisztulni feltöltődni harmonizálni a test–lélek rendszerét.\nLegyen szó otthoni relaxációról, terápiás munkáról vagy professzionális hangkezelésről, nálunk megtalálod a fejlődésedhez szükséges hangszereket és tudást.\n\nVálogass prémium kategóriáinkból:\n\n• Himalájai hangtálak\n• Meinl Sonic Energy hangszerek\n• Kristálytálak\n• Hangvillák és frekvenciaeszközök\n• Gongok és rezgésterápiás hangszerek\n• Egyedi tálpárosítások, személyre szabott ajánlással\n• Exkluzív kiegészítők és tartozékok\n\nNálunk minden hangnak története van.",    
+    "subtitle": "Merülj el a hangok gyógyító rezgésében.",
+    "description": "Eszközeink segítenek: megnyugodni elmélyülni tisztulni feltöltődni harmonizálni a test–lélek rendszerét.\nLegyen szó otthoni relaxációról, terápiás munkáról vagy professzionális hangkezelésről, nálunk megtalálod a fejlődésedhez szükséges hangszereket és tudást.\n\nVálogass prémium kategóriáinkból:\n\n• Himalájai hangtálak\n• Meinl Sonic Energy hangszerek\n• Kristálytálak\n• Hangvillák és frekvenciaeszközök\n• Gongok és rezgésterápiás hangszerek\n• Egyedi tálpárosítások, személyre szabott ajánlással\n• Exkluzív kiegészítők és tartozékok\n\nNálunk minden hangnak története van.",
     "imageAlt": "Hangterápiás hangszerek"
   },
   "categories": {
@@ -105,36 +105,35 @@
       "easyReturns": "Könnyű visszaküldés"
     }
   },
-"checkout": {
-  "title": "Fizetés",
-  "fields": {
-    "first_name": "Keresztnév",
-    "last_name": "Vezetéknév",
-    "address_1": "Cím",
-    "city": "Város",
-    "state": "Állam / Megye",
-    "postcode": "Irányítószám",
-    "country": "Ország",
-    "email": "Email",
-    "phone": "Telefonszám"
+  "checkout": {
+    "title": "Fizetés",
+    "fields": {
+      "first_name": "Keresztnév",
+      "last_name": "Vezetéknév",
+      "address_1": "Cím",
+      "city": "Város",
+      "state": "Állam / Megye",
+      "postcode": "Irányítószám",
+      "country": "Ország",
+      "email": "Email",
+      "phone": "Telefonszám"
+    },
+    "cartSummary": "Kosár összegzés",
+    "cart": {
+      "image": "Kép",
+      "product": "Termék",
+      "unitPrice": "Egységár",
+      "quantity": "Mennyiség",
+      "action": "Művelet",
+      "remove": "Eltávolítás"
+    },
+    "total": "Összesen",
+    "payButton": "Fizetés Stripe-on",
+    "redirecting": "Átirányítás a Stripe fizetésre...",
+    "emptyCart": "A kosár üres.",
+    "stripeFailed": "A Stripe fizetés létrehozása sikertelen.",
+    "disclaimer": "A vásárlás befejezéséhez átirányítunk a Stripe biztonságos fizetési oldalára."
   },
-  "cartSummary": "Kosár összegzés",
-  "cart": {
-    "image": "Kép",
-    "product": "Termék",
-    "unitPrice": "Egységár",
-    "quantity": "Mennyiség",
-    "action": "Művelet",
-    "remove": "Eltávolítás"
-  },
-  "total": "Összesen",
-  "payButton": "Fizetés Stripe-on",
-  "redirecting": "Átirányítás a Stripe fizetésre...",
-  "emptyCart": "A kosár üres.",
-  "stripeFailed": "A Stripe fizetés létrehozása sikertelen.",
-  "disclaimer": "A vásárlás befejezéséhez átirányítunk a Stripe biztonságos fizetési oldalára."
-},
-
   "cart": {
     "title": "Bevásárló kosár",
     "emptyMessage": "A kosár üres.",
@@ -157,25 +156,175 @@
     "removed": "A termék eltávolítva a kosárból!"
   },
   "about": {
-    "title": "Adrienn Pál",
-    "intro1": "Adrienn Pál elkötelezett abban, hogy a hang gyógyító erejét mindenkihez eljuttassa. Üdvözöllek a Hangakadémia webshopjában! Célom, hogy a hangok és rezgések gyógyító, harmonizáló ereje mindenki számára elérhető legyen.",
-"intro2": "A nálunk kapható hangtálak, gongok, hangvillák és különleges hangszerek mind a test és lélek egyensúlyát szolgálják – legyen szó relaxációról, meditációról, terápiáról vagy egyszerűen a mindennapi belső harmónia megteremtéséről.\nMinden hangszerhez szakértői tanácsot, részletes leírást és gyakorlati útmutatót is biztosítok, ha szeretnéd. A hangszerekről bővebben tanulhatsz, gyakorolhatsz a képzéseimen– mert hiszem, hogy a hang nem csupán megszólal, hanem tanít, gyógyít és összekapcsol.",
-    "imageAlt": "Adrienn Pál portréja",
-    "mission": "Miért a Hangakadémia®? Miért válassz minket?",
-"missionText": "Szakmai útmutatás minden termékhez\nNem csak vásárolsz támogatást is kapsz.\nMegtanítjuk, hogyan válaszd ki a hozzád illő hangtálat, milyen frekvenciát, méretet vagy rezgést érdemes használni, és hogyan illeszd be a mindennapi rutinodba.\n\nTanuld meg a hangok erejét\nA HangAkadémiánál® nem csupán webshop, hanem oktatási tér is.\nOnline és személyes képzéseinken megismerheted a hangtálmasszázs, hangfürdők, hangvillák és rezgésterápia világát — a kezdőtől a haladó szintig.\n\nMerülj el a hangok gyógyító rezgésében\nEszközeink segítenek:\n megnyugodni\n elmélyülni\n tisztulni\n feltöltődni\n harmonizálni a test–lélek rendszerét\n\nLegyen szó otthoni relaxációról, terápiás munkáról vagy professzionális hangkezelésről, nálunk megtalálod a fejlődésedhez szükséges hangszereket és tudást ",
-    "faq": "Gyakran Ismételt Kérdések",
-    "faqItems": {
-      "soundHealing": "Mi az a hangterápia?",
-      "chooseInstrument": "Hogyan válasszam ki a megfelelő hangszert?",
-      "workshops": "Tartotok workshopokat?",
-      "benefits": "Milyen előnyei vannak a hangterápiának?"
-    },
-    "faqAnswers": {
-      "soundHealing": "A hangterápia olyan módszer, amely hangszerek rezgéseit használja a testi és lelki jóllét elősegítésére.",
-      "chooseInstrument": "Fontos a szándék és a személyes preferencia. Szívesen segítünk megtalálni a számodra tökéletes hangszert.",
-      "workshops": "Igen, minden szinten tartunk workshopokat. Nézd meg eseményeinket a részletekért.",
-      "benefits": "A hangterápia segíthet a stressz csökkentésében, a fókusz javításában és az általános egészség támogatásában."
-    }
+    "title": "A HangAkadémia® – ahol a hang tudássá válik",
+    "imageAlt": "A HangAkadémia® alapítója",
+    "introParagraphs": [
+      "A HangAkadémia® egy strukturált szakmai szemlélet mentén működő webshop, amelynek kínálata következetes szakmai szűrés és tapasztalati alapú válogatás eredménye.",
+      "A hangszerek itt nem pusztán termékek, hanem olyan eszközök, amelyek hangzásukban, karakterükben és funkcionális alkalmazhatóságukban is megfelelnek a képviselt szakmai elveknek."
+    ],
+    "sections": [
+      {
+        "title": "A HangAkadémia® célja",
+        "paragraphs": [
+          "A HangAkadémia® célja, hogy világos, megbízható és szakmailag értelmezhető választási keretet biztosítson mindazok számára, akik a hangszerekkel való munkát tudatos döntésekre, felelősségvállalásra és hosszú távú szemléletre alapozzák – legyen szó személyes használatról, oktatási környezetről vagy professzionális gyakorlatról."
+        ]
+      },
+      {
+        "title": "Pál Adrienn– alapító, szakmai vezető",
+        "paragraphs": [
+          "Pál Adrienn a HangAkadémia® alapítója és szakmai vezetője.",
+          "Munkájának középpontjában a hangtálak, hangvillák, gongok és egyéb rezgésalapú hangszerek tudatos, felelős és szakmailag megalapozott alkalmazása áll."
+        ],
+        "listTitle": "Számára kiemelten fontos, hogy minden hangszer:",
+        "listItems": [
+          "minőségében ellenőrzött legyen",
+          "hangzásában tiszta és kiegyensúlyozott",
+          "rezgéskarakterében következetes",
+          "és valódi szakmai értéket képviseljen"
+        ],
+        "closingParagraph": "A HangAkadémia® webshop kínálata ennek a szemléletnek az eredménye: minden hangszer személyes válogatáson és szakmai szűrésen megy keresztül."
+      },
+      {
+        "title": "Hivatalos szakmai háttér",
+        "paragraphs": [
+          "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere.",
+          "Pál Adriennl Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete, közvetlen kapcsolatban a gyártó nemzetközi csapatával."
+        ],
+        "listTitle": "Ez a szakmai együttműködés biztosítja, hogy a webshopban:",
+        "listItems": [
+          "kizárólag eredeti, ellenőrzött forrásból származó hangszerek jelenjenek meg",
+          "naprakész termékkínálat legyen elérhető",
+          "hiteles, szakmailag megalapozott információk álljanak a vásárlók rendelkezésére"
+        ]
+      },
+      {
+        "title": "Miért válaszd a HangAkadémiát?",
+        "features": [
+          {
+            "title": "Személyesen válogatott hangszerek",
+            "description": "Minden hangszer gondos kiválasztás eredménye. A hang tisztasága, a rezgés minősége és az anyaghasználat alapvető szempont a kínálat összeállításakor."
+          },
+          {
+            "title": "Szakértői útmutatás",
+            "description": "A HangAkadémiánál® nem csupán vásárolsz. Segítünk eligazodni a hangmagasságok, frekvenciák, méretek és hangkarakterek között, hogy valóban a hozzád illő hangszer kerüljön hozzád."
+          },
+          {
+            "title": "Oktatási háttér",
+            "description": "A Hangakadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
+          },
+          {
+            "title": "Prémium minőség és biztonság",
+            "description": "A hangszereket gondosan csomagolva, fokozott figyelemmel juttatjuk el hozzád, hogy a minőség már az első megszólaláskor érezhető legyen."
+          }
+        ]
+      },
+      {
+        "title": "A Hangakadémia® szemlélete",
+        "paragraphs": [
+          "A HangAkadémiánál® a hang egyszerre élmény és minőség.",
+          "Lehet önfeledt, lehet elmélyítő, lehet inspiráló – számunkra azonban mindig fontos, hogyan szólal meg, milyen minőséget képvisel, és milyen kapcsolatot teremt az ember és a hangszer között.",
+          "Minden hangszer, amely a kínálatunkba kerül, ezt a szemléletet tükrözi: tudatos választás, tiszta hangzás és szakmai megbízhatóság."
+        ]
+      }
+    ],
+    "faqTitle": "GYIK",
+    "faqItems": [
+      {
+        "question": "Mi az a hangterápia / hangalapú hangmunka?",
+        "answerParagraphs": [
+          "A hangterápia a hang és a rezgés tudatos alkalmazásán alapuló megközelítés, amely különböző hangszerek segítségével a hallás, az észlelés és a figyelem folyamatára épül.",
+          "A gyakorlat középpontjában nem diagnózis vagy gyógyítás áll, hanem a hangélmény strukturált, célzott használata egyéni vagy csoportos környezetben."
+        ]
+      },
+      {
+        "question": "Milyen célra használhatók a webshopban kapható hangszerek?",
+        "answerParagraphs": ["A HangAkadémia® kínálatában szereplő hangszerek használhatók:"],
+        "listItems": [
+          "otthoni relaxációra",
+          "meditációs vagy figyelem fókuszáló gyakorlatokhoz",
+          "oktatási környezetben",
+          "professzionális hangmunkához (pl. hangfürdők, csoportos hangélmények)"
+        ],
+        "closing": "A hangszerek nem minősülnek orvosi vagy terápiás eszköznek."
+      },
+      {
+        "question": "Hogyan válasszam ki a számomra megfelelő hangszert?",
+        "answerParagraphs": ["A megfelelő hangszer kiválasztása több tényezőtől függ, például:"],
+        "listItems": [
+          "milyen célra szeretnéd használni",
+          "milyen hangmagasság vagy hangkarakter áll közel hozzád",
+          "otthoni vagy professzionális környezetben alkalmazod-e"
+        ],
+        "closing": "Ha bizonytalan vagy, lehetőséget biztosítunk személyre szabott szakmai ajánlásra, amely segít eligazodni a kínálatban."
+      },
+      {
+        "question": "Miben különbözik a HangAkadémia® webshop más hangszer webshopoktól?",
+        "answerParagraphs": [
+          "A HangAkadémia® kínálata nem tömeges termékkatalógus.",
+          "Minden hangszer szakmai szempontok szerint válogatott, személyes tapasztalaton és következetes szemléleten alapul.",
+          "A webshop mögött aktív oktatási és szakmai háttér áll, amely biztosítja a hiteles tájékoztatást és az egységes minőségi szemléletet."
+        ]
+      },
+      {
+        "question": "Kapok segítséget a hangszerek használatához?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® célja, hogy a vásárlók ne csak hangszert kapjanak, hanem érthető szakmai útmutatást is."
+        ],
+        "listItems": [
+          "termékleírásokon keresztül",
+          "egyedi ajánlás formájában",
+          "oktatási anyagokon és képzéseken keresztül"
+        ]
+      },
+      {
+        "question": "Tartotok képzéseket, workshopokat?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® oktatási tevékenysége keretében online és személyes képzéseket is kínál, strukturált rendszerben, különböző szinteken."
+        ],
+        "closing": "Az aktuális képzések és események mindig a hivatalos felületekeinken érhetők el.",
+        "linkText": "Oktatások megtekintése",
+        "linkUrl": "https://hangakademia.hu/oktatasok.html"
+      },
+      {
+        "question": "A hangszerek rendelkeznek egészségügyi vagy gyógyászati hatással?",
+        "answerParagraphs": [
+          "A webshopban kapható hangszerek nem egészségügyi eszközök, és nem helyettesítenek orvosi vagy terápiás kezeléseket.",
+          "A hangszerek használata élményalapú, oktatási és kreatív célokat szolgál."
+        ]
+      },
+      {
+        "question": "Kezdők is vásárolhatnak a webshopból?",
+        "answerParagraphs": [
+          "Igen.",
+          "A kínálat összeállításakor figyelünk arra, hogy kezdők számára is jól használható hangszerek elérhetők legyenek, megfelelő szakmai magyarázattal és ajánlással."
+        ]
+      },
+      {
+        "question": "Professzionális felhasználók számára is megfelelőek a hangszerek?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® kínálata alkalmas professzionális hangmunkára is, például:"
+        ],
+        "listItems": [
+          "csoportos hangélményekhez",
+          "oktatáshoz",
+          "különböző hangfürdők lebonyolításához"
+        ],
+        "closing": "A választásnál azonban fontos a megfelelő hangszer és méret kiválasztása."
+      },
+      {
+        "question": "Mit tegyek, ha nem vagyok biztos a választásomban?",
+        "answerParagraphs": [
+          "Ha bizonytalan vagy, javasoljuk, hogy vedd fel velünk a kapcsolatot.",
+          "Szívesen segítünk eligazodni a hangszerek között, és szakmai szempontok alapján ajánlunk megoldást."
+        ]
+      }
+    ],
+    "quoteLabel": "Személyes üzenet tőlem",
+    "quoteText": "„A hanggal való munka számomra figyelmet és tiszteletet jelent. Minden hangszer, amely a Hangakadémián megjelenik, ezen a szemléleten keresztül érkezik.”",
+    "quoteAuthor": "— Adrienn Pál"
   },
   "contact": {
     "title": "Kapcsolat",
@@ -299,7 +448,6 @@
     "cancel": "Mégsem",
     "delete": "Törlés"
   },
-
   "notFound": {
     "title": "Az oldal nem található",
     "message": "A keresett oldal nem létezik.",
@@ -344,14 +492,16 @@
     "errorText": "Hiba történt a rendelés törlése során. Kérem, próbáld újra.",
     "cart.action": {
       "delete": "Törlés"
-  },
-  "promo": {
-    "title": "Miért válassz minket?",
-    "intro": "A HangAkadémiánál® a hang több mint rezgés:kapocs önmagadhoz, a jelen pillanathoz, és ahhoz a belső harmóniához, amelyre mindannyian vágyunk.",
-    "point1": "Minőségi, válogatott hangszerek",
-    "point2": "Szakértői útmutatás és oktatás",
-    "point3": "Gyors, biztonságos szállítás",
-    "point4": "A hangszereket gondosan csomagoljuk és extra figyelemmel küldjük útnak.Lépj be a hangok világába.",
-    "outro": "Válassz most webshopunk prémium kínálatából, és találd meg azt az eszközt, amely megszólít —a rezgést, amely elindít a belső harmónia útján.",
-    "cta": "Meinl Sonic Energy Magyarországi Szakmai Nagykövet megtekintése"
-  }}}
+    },
+    "promo": {
+      "title": "Miért válassz minket?",
+      "intro": "A HangAkadémiánál® a hang több mint rezgés:kapocs önmagadhoz, a jelen pillanathoz, és ahhoz a belső harmóniához, amelyre mindannyian vágyunk.",
+      "point1": "Minőségi, válogatott hangszerek",
+      "point2": "Szakértői útmutatás és oktatás",
+      "point3": "Gyors, biztonságos szállítás",
+      "point4": "A hangszereket gondosan csomagoljuk és extra figyelemmel küldjük útnak.Lépj be a hangok világába.",
+      "outro": "Válassz most webshopunk prémium kínálatából, és találd meg azt az eszközt, amely megszólít —a rezgést, amely elindít a belső harmónia útján.",
+      "cta": "Meinl Sonic Energy Magyarországi Szakmai Nagykövet megtekintése"
+    }
+  }
+}

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -154,25 +154,175 @@
     "removed": "Produkt bol odstránený z košíka!"
   },
   "about": {
-    "title": "Adrienn Pál",
-    "intro1": "Adrienn Pál sa venuje tomu, aby liečivá sila zvuku bola dostupná pre každého. Vitajte v e-shope Zvukovej akadémie! Mojím cieľom je sprístupniť liečivú, harmonizujúcu silu zvukov a vibrácií všetkým.",
-    "intro2": "Spievajúce misy, gongy, ladičky a špeciálne nástroje dostupné tu slúžia rovnováhe tela a duše – či už na relaxáciu, meditáciu, terapiu alebo jednoducho na každodennú vnútornú harmóniu.\nKu každému nástroju dostanete odborné rady, podrobné popisy a praktické vedenie, ak si želáte. O nástrojoch sa môžete dozvedieť viac a cvičiť na mojich školeniach – verím, že zvuk nielen znie, ale aj učí, lieči a spája.",
-    "imageAlt": "Portrét Adrienn Pál",
-    "mission": "Prečo si vybrať nás?",
-    "missionText": "Starostlivo vybrané, prémiové nástroje\nJedinečné popisy spievajúcich mís (frekvencia, zvuk, spojenie s čakrou) – špeciálna služba len u nás\nOdborné vedenie a vzdelávacie zázemie\nRýchle, bezpečné doručenie.",
-    "faq": "Často kladené otázky",
-    "faqItems": {
-      "soundHealing": "Čo je zvuková terapia?",
-      "chooseInstrument": "Ako si vybrať správny nástroj?",
-      "workshops": "Ponúkate workshopy?",
-      "benefits": "Aké sú výhody zvukovej terapie?"
-    },
-    "faqAnswers": {
-      "soundHealing": "Zvuková terapia je metóda, ktorá využíva vibrácie nástrojov na podporu fyzickej a duševnej pohody.",
-      "chooseInstrument": "Dôležitý je zámer a osobné preferencie. Radi vám pomôžeme nájsť dokonalý nástroj.",
-      "workshops": "Áno, ponúkame workshopy pre všetky úrovne. Pozrite si naše podujatia pre podrobnosti.",
-      "benefits": "Zvuková terapia môže pomôcť znížiť stres, zlepšiť koncentráciu a podporiť zdravie."
-    }
+    "title": "A HangAkadémia® – ahol a hang tudássá válik",
+    "imageAlt": "A HangAkadémia® alapítója",
+    "introParagraphs": [
+      "A HangAkadémia® egy strukturált szakmai szemlélet mentén működő webshop, amelynek kínálata következetes szakmai szűrés és tapasztalati alapú válogatás eredménye.",
+      "A hangszerek itt nem pusztán termékek, hanem olyan eszközök, amelyek hangzásukban, karakterükben és funkcionális alkalmazhatóságukban is megfelelnek a képviselt szakmai elveknek."
+    ],
+    "sections": [
+      {
+        "title": "A HangAkadémia® célja",
+        "paragraphs": [
+          "A HangAkadémia® célja, hogy világos, megbízható és szakmailag értelmezhető választási keretet biztosítson mindazok számára, akik a hangszerekkel való munkát tudatos döntésekre, felelősségvállalásra és hosszú távú szemléletre alapozzák – legyen szó személyes használatról, oktatási környezetről vagy professzionális gyakorlatról."
+        ]
+      },
+      {
+        "title": "Pál Adrienn– alapító, szakmai vezető",
+        "paragraphs": [
+          "Pál Adrienn a HangAkadémia® alapítója és szakmai vezetője.",
+          "Munkájának középpontjában a hangtálak, hangvillák, gongok és egyéb rezgésalapú hangszerek tudatos, felelős és szakmailag megalapozott alkalmazása áll."
+        ],
+        "listTitle": "Számára kiemelten fontos, hogy minden hangszer:",
+        "listItems": [
+          "minőségében ellenőrzött legyen",
+          "hangzásában tiszta és kiegyensúlyozott",
+          "rezgéskarakterében következetes",
+          "és valódi szakmai értéket képviseljen"
+        ],
+        "closingParagraph": "A HangAkadémia® webshop kínálata ennek a szemléletnek az eredménye: minden hangszer személyes válogatáson és szakmai szűrésen megy keresztül."
+      },
+      {
+        "title": "Hivatalos szakmai háttér",
+        "paragraphs": [
+          "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere.",
+          "Pál Adriennl Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete, közvetlen kapcsolatban a gyártó nemzetközi csapatával."
+        ],
+        "listTitle": "Ez a szakmai együttműködés biztosítja, hogy a webshopban:",
+        "listItems": [
+          "kizárólag eredeti, ellenőrzött forrásból származó hangszerek jelenjenek meg",
+          "naprakész termékkínálat legyen elérhető",
+          "hiteles, szakmailag megalapozott információk álljanak a vásárlók rendelkezésére"
+        ]
+      },
+      {
+        "title": "Miért válaszd a HangAkadémiát?",
+        "features": [
+          {
+            "title": "Személyesen válogatott hangszerek",
+            "description": "Minden hangszer gondos kiválasztás eredménye. A hang tisztasága, a rezgés minősége és az anyaghasználat alapvető szempont a kínálat összeállításakor."
+          },
+          {
+            "title": "Szakértői útmutatás",
+            "description": "A HangAkadémiánál® nem csupán vásárolsz. Segítünk eligazodni a hangmagasságok, frekvenciák, méretek és hangkarakterek között, hogy valóban a hozzád illő hangszer kerüljön hozzád."
+          },
+          {
+            "title": "Oktatási háttér",
+            "description": "A Hangakadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
+          },
+          {
+            "title": "Prémium minőség és biztonság",
+            "description": "A hangszereket gondosan csomagolva, fokozott figyelemmel juttatjuk el hozzád, hogy a minőség már az első megszólaláskor érezhető legyen."
+          }
+        ]
+      },
+      {
+        "title": "A Hangakadémia® szemlélete",
+        "paragraphs": [
+          "A HangAkadémiánál® a hang egyszerre élmény és minőség.",
+          "Lehet önfeledt, lehet elmélyítő, lehet inspiráló – számunkra azonban mindig fontos, hogyan szólal meg, milyen minőséget képvisel, és milyen kapcsolatot teremt az ember és a hangszer között.",
+          "Minden hangszer, amely a kínálatunkba kerül, ezt a szemléletet tükrözi: tudatos választás, tiszta hangzás és szakmai megbízhatóság."
+        ]
+      }
+    ],
+    "faqTitle": "GYIK",
+    "faqItems": [
+      {
+        "question": "Mi az a hangterápia / hangalapú hangmunka?",
+        "answerParagraphs": [
+          "A hangterápia a hang és a rezgés tudatos alkalmazásán alapuló megközelítés, amely különböző hangszerek segítségével a hallás, az észlelés és a figyelem folyamatára épül.",
+          "A gyakorlat középpontjában nem diagnózis vagy gyógyítás áll, hanem a hangélmény strukturált, célzott használata egyéni vagy csoportos környezetben."
+        ]
+      },
+      {
+        "question": "Milyen célra használhatók a webshopban kapható hangszerek?",
+        "answerParagraphs": ["A HangAkadémia® kínálatában szereplő hangszerek használhatók:"],
+        "listItems": [
+          "otthoni relaxációra",
+          "meditációs vagy figyelem fókuszáló gyakorlatokhoz",
+          "oktatási környezetben",
+          "professzionális hangmunkához (pl. hangfürdők, csoportos hangélmények)"
+        ],
+        "closing": "A hangszerek nem minősülnek orvosi vagy terápiás eszköznek."
+      },
+      {
+        "question": "Hogyan válasszam ki a számomra megfelelő hangszert?",
+        "answerParagraphs": ["A megfelelő hangszer kiválasztása több tényezőtől függ, például:"],
+        "listItems": [
+          "milyen célra szeretnéd használni",
+          "milyen hangmagasság vagy hangkarakter áll közel hozzád",
+          "otthoni vagy professzionális környezetben alkalmazod-e"
+        ],
+        "closing": "Ha bizonytalan vagy, lehetőséget biztosítunk személyre szabott szakmai ajánlásra, amely segít eligazodni a kínálatban."
+      },
+      {
+        "question": "Miben különbözik a HangAkadémia® webshop más hangszer webshopoktól?",
+        "answerParagraphs": [
+          "A HangAkadémia® kínálata nem tömeges termékkatalógus.",
+          "Minden hangszer szakmai szempontok szerint válogatott, személyes tapasztalaton és következetes szemléleten alapul.",
+          "A webshop mögött aktív oktatási és szakmai háttér áll, amely biztosítja a hiteles tájékoztatást és az egységes minőségi szemléletet."
+        ]
+      },
+      {
+        "question": "Kapok segítséget a hangszerek használatához?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® célja, hogy a vásárlók ne csak hangszert kapjanak, hanem érthető szakmai útmutatást is."
+        ],
+        "listItems": [
+          "termékleírásokon keresztül",
+          "egyedi ajánlás formájában",
+          "oktatási anyagokon és képzéseken keresztül"
+        ]
+      },
+      {
+        "question": "Tartotok képzéseket, workshopokat?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® oktatási tevékenysége keretében online és személyes képzéseket is kínál, strukturált rendszerben, különböző szinteken."
+        ],
+        "closing": "Az aktuális képzések és események mindig a hivatalos felületekeinken érhetők el.",
+        "linkText": "Oktatások megtekintése",
+        "linkUrl": "https://hangakademia.hu/oktatasok.html"
+      },
+      {
+        "question": "A hangszerek rendelkeznek egészségügyi vagy gyógyászati hatással?",
+        "answerParagraphs": [
+          "A webshopban kapható hangszerek nem egészségügyi eszközök, és nem helyettesítenek orvosi vagy terápiás kezeléseket.",
+          "A hangszerek használata élményalapú, oktatási és kreatív célokat szolgál."
+        ]
+      },
+      {
+        "question": "Kezdők is vásárolhatnak a webshopból?",
+        "answerParagraphs": [
+          "Igen.",
+          "A kínálat összeállításakor figyelünk arra, hogy kezdők számára is jól használható hangszerek elérhetők legyenek, megfelelő szakmai magyarázattal és ajánlással."
+        ]
+      },
+      {
+        "question": "Professzionális felhasználók számára is megfelelőek a hangszerek?",
+        "answerParagraphs": [
+          "Igen.",
+          "A HangAkadémia® kínálata alkalmas professzionális hangmunkára is, például:"
+        ],
+        "listItems": [
+          "csoportos hangélményekhez",
+          "oktatáshoz",
+          "különböző hangfürdők lebonyolításához"
+        ],
+        "closing": "A választásnál azonban fontos a megfelelő hangszer és méret kiválasztása."
+      },
+      {
+        "question": "Mit tegyek, ha nem vagyok biztos a választásomban?",
+        "answerParagraphs": [
+          "Ha bizonytalan vagy, javasoljuk, hogy vedd fel velünk a kapcsolatot.",
+          "Szívesen segítünk eligazodni a hangszerek között, és szakmai szempontok alapján ajánlunk megoldást."
+        ]
+      }
+    ],
+    "quoteLabel": "Személyes üzenet tőlem",
+    "quoteText": "„A hanggal való munka számomra figyelmet és tiszteletet jelent. Minden hangszer, amely a Hangakadémián megjelenik, ezen a szemléleten keresztül érkezik.”",
+    "quoteAuthor": "— Adrienn Pál"
   },
   "contact": {
     "title": "Kontakt",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { useTranslation } from 'react-i18next';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 type Feature = {
   title: string;
@@ -101,43 +102,39 @@ const About = () => {
           {faqItems?.length > 0 && (
             <section className="space-y-4">
               <h2 className="text-3xl font-bold text-primary">{faqTitle}</h2>
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <Accordion type="multiple" className="divide-y rounded-lg border">
                 {faqItems.map((faq) => (
-                  <div
-                    key={faq.question}
-                    className="h-full p-4 rounded-lg border bg-muted/50 space-y-2"
-                  >
-                    <h3 className="text-xl font-semibold text-primary">{faq.question}</h3>
+                  <AccordionItem key={faq.question} value={faq.question} className="px-4">
+                    <AccordionTrigger className="text-lg text-primary">{faq.question}</AccordionTrigger>
+                    <AccordionContent className="space-y-3 text-foreground">
+                      {faq.answerParagraphs?.map((paragraph, index) => (
+                        <p key={index}>{paragraph}</p>
+                      ))}
 
-                    {faq.answerParagraphs?.map((paragraph, index) => (
-                      <p key={index} className="text-foreground">
-                        {paragraph}
-                      </p>
-                    ))}
+                      {faq.listItems && (
+                        <ul className="list-disc list-inside space-y-1">
+                          {faq.listItems.map((item, index) => (
+                            <li key={index}>{item}</li>
+                          ))}
+                        </ul>
+                      )}
 
-                    {faq.listItems && (
-                      <ul className="list-disc list-inside space-y-1 text-foreground">
-                        {faq.listItems.map((item, index) => (
-                          <li key={index}>{item}</li>
-                        ))}
-                      </ul>
-                    )}
+                      {faq.closing && <p>{faq.closing}</p>}
 
-                    {faq.closing && <p className="text-foreground">{faq.closing}</p>}
-
-                    {faq.linkUrl && faq.linkText && (
-                      <a
-                        href={faq.linkUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline font-medium"
-                      >
-                        {faq.linkText}
-                      </a>
-                    )}
-                  </div>
+                      {faq.linkUrl && faq.linkText && (
+                        <a
+                          href={faq.linkUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline font-medium"
+                        >
+                          {faq.linkText}
+                        </a>
+                      )}
+                    </AccordionContent>
+                  </AccordionItem>
                 ))}
-              </div>
+              </Accordion>
             </section>
           )}
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,34 +1,55 @@
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { useTranslation } from 'react-i18next';
+
+type Feature = {
+  title: string;
+  description: string;
+};
+
+type Section = {
+  title: string;
+  paragraphs?: string[];
+  listTitle?: string;
+  listItems?: string[];
+  closingParagraph?: string;
+  features?: Feature[];
+};
+
+type FAQItem = {
+  question: string;
+  answerParagraphs?: string[];
+  listItems?: string[];
+  closing?: string;
+  linkText?: string;
+  linkUrl?: string;
+};
 
 const About = () => {
   const { t } = useTranslation();
+
+  const introParagraphs = t('about.introParagraphs', { returnObjects: true }) as string[];
+  const sections = t('about.sections', { returnObjects: true }) as Section[];
+  const faqTitle = t('about.faqTitle');
+  const faqItems = t('about.faqItems', { returnObjects: true }) as FAQItem[];
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar />
       
       <div className="container py-12">
-        <div className="max-w-4xl mx-auto">
-          <div className="grid md:grid-cols-2 gap-8 items-center mb-16">
+        <div className="max-w-4xl mx-auto space-y-12">
+          <div className="grid md:grid-cols-2 gap-8 items-center">
             <div>
               <h1 className="text-4xl font-bold text-primary mb-6">{t('about.title')}</h1>
-              <p className="text-foreground mb-4">
-                {t('about.intro1')}
-              </p>
-              <p className="text-foreground">
-                {t('about.intro2')}
-              </p>
+              {introParagraphs?.map((paragraph, index) => (
+                <p key={index} className="text-foreground mb-4">
+                  {paragraph}
+                </p>
+              ))}
             </div>
             <div className="relative h-[400px] rounded-lg overflow-hidden">
-              <img 
+              <img
                 src="/images/Ardi1.webp"
                 alt={t('about.imageAlt')}
                 className="w-full h-full object-cover"
@@ -36,45 +57,102 @@ const About = () => {
             </div>
           </div>
 
-          <div className="mb-16">
-            <h2 className="text-3xl font-bold text-primary mb-8">{t('about.mission')}</h2>
-            <p className="text-foreground mb-4">
-              {t('about.missionText')}
-            </p>
-          </div>
+          {sections?.map((section, index) => (
+            <section key={`${section.title}-${index}`} className="space-y-4">
+              <h2 className="text-3xl font-bold text-primary">{section.title}</h2>
 
-          <div>
-            <h2 className="text-3xl font-bold text-primary mb-8">{t('about.faq')}</h2>
-            <Accordion type="single" collapsible className="w-full">
-              <AccordionItem value="item-1">
-                <AccordionTrigger>{t('about.faqItems.soundHealing')}</AccordionTrigger>
-                <AccordionContent>
-                  {t('about.faqAnswers.soundHealing')}
-                </AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="item-2">
-                <AccordionTrigger>{t('about.faqItems.chooseInstrument')}</AccordionTrigger>
-                <AccordionContent>
-                  {t('about.faqAnswers.chooseInstrument')}
-                </AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="item-3">
-                <AccordionTrigger>{t('about.faqItems.workshops')}</AccordionTrigger>
-                <AccordionContent>
-                  {t('about.faqAnswers.workshops')}
-                </AccordionContent>
-              </AccordionItem>
-              <AccordionItem value="item-4">
-                <AccordionTrigger>{t('about.faqItems.benefits')}</AccordionTrigger>
-                <AccordionContent>
-                  {t('about.faqAnswers.benefits')}
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
+              {section.paragraphs?.map((paragraph, paragraphIndex) => (
+                <p key={paragraphIndex} className="text-foreground">
+                  {paragraph}
+                </p>
+              ))}
+
+              {section.listTitle && section.listItems && (
+                <div className="space-y-2">
+                  <p className="font-semibold text-foreground">{section.listTitle}</p>
+                  <ul className="list-disc list-inside space-y-1 text-foreground">
+                    {section.listItems.map((item, itemIndex) => (
+                      <li key={itemIndex}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {section.features && (
+                <div className="grid md:grid-cols-2 gap-4">
+                  {section.features.map((feature) => (
+                    <div
+                      key={feature.title}
+                      className="p-4 rounded-lg border bg-muted/50 space-y-2"
+                    >
+                      <h3 className="text-xl font-semibold text-primary">{feature.title}</h3>
+                      <p className="text-foreground">{feature.description}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {section.closingParagraph && (
+                <p className="text-foreground">{section.closingParagraph}</p>
+              )}
+            </section>
+          ))}
+
+          {faqItems?.length > 0 && (
+            <section className="space-y-4">
+              <h2 className="text-3xl font-bold text-primary">{faqTitle}</h2>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {faqItems.map((faq) => (
+                  <div
+                    key={faq.question}
+                    className="h-full p-4 rounded-lg border bg-muted/50 space-y-2"
+                  >
+                    <h3 className="text-xl font-semibold text-primary">{faq.question}</h3>
+
+                    {faq.answerParagraphs?.map((paragraph, index) => (
+                      <p key={index} className="text-foreground">
+                        {paragraph}
+                      </p>
+                    ))}
+
+                    {faq.listItems && (
+                      <ul className="list-disc list-inside space-y-1 text-foreground">
+                        {faq.listItems.map((item, index) => (
+                          <li key={index}>{item}</li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {faq.closing && <p className="text-foreground">{faq.closing}</p>}
+
+                    {faq.linkUrl && faq.linkText && (
+                      <a
+                        href={faq.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline font-medium"
+                      >
+                        {faq.linkText}
+                      </a>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <div className="bg-muted/60 p-6 rounded-lg border space-y-2">
+            <p className="text-sm font-medium text-primary uppercase tracking-wide">
+              {t('about.quoteLabel')}
+            </p>
+            <blockquote className="text-lg text-foreground italic">
+              {t('about.quoteText')}
+            </blockquote>
+            <p className="text-foreground">{t('about.quoteAuthor')}</p>
           </div>
         </div>
       </div>
-      
+
       <Footer />
     </div>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,38 +39,45 @@ const Index = () => {
 			<Hero />
 
 			{/* Promo Section */}
-			<section className="container py-16 bg-background w-full text-center max-w-4xl mx-auto">
-				<h2 className="text-4xl font-bold mb-8">
-					{t("promo.title", "Miért válassz minket?")}
-				</h2>
-				<div className="mb-8 text-lg text-gray-700 max-w-lg mx-auto">
-					<p>
-						{t(
-							"promo.intro",
-							"Fedezd fel gondosan válogatott, kézzel készített hangszereink és egyedi alkotásaink világát."
-						)}
-					</p>
-					<ul className="list-none space-y-2 text-middle mt-4">
-						<li> {t("promo.point1", "Minőségi, válogatott hangszerek")}</li>
-						<li> {t("promo.point2", "Szakértői útmutatás és oktatás")}</li>
-						<li>
-							 {t("promo.point3", "Egyedi táblázatok, leírások a hangtálak mellé – csak nálunk")}
-						</li>
-						<li> {t("promo.point4", "Gyors, biztonságos szállítás")}</li>
-					</ul>
-					<p>
-						{t(
-							"promo.outro",
-							"Engedd, hogy a hangok ereje belépjen a mindennapjaidba  válassz most webshopunk kínálatából."
-						)}
-					</p>
-				</div>
-				<Link to="https://hangakademia.hu" target="_blank" rel="noopener noreferrer">
-					<button className="bg-primary text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-primary/90 transition">
-						{t("promo.cta", "MeinSonic Energy Nagykövet megtekintése")}
-					</button>
-				</Link>
-			</section>
+                        <section className="container py-16 bg-background w-full max-w-4xl mx-auto">
+                                <h2 className="text-4xl font-bold mb-8 text-center">
+                                        {t("promo.title", "HANGAKADÉMIA® – A hangok ereje a mindennapjaidban")}
+                                </h2>
+                                <div className="mb-8 text-lg text-gray-700 space-y-4 leading-relaxed">
+                                        <p>{t("promo.intro", "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.")}</p>
+                                        <p>
+                                                {t(
+                                                        "promo.belief",
+                                                        "A Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet. Webshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással."
+                                                )}
+                                        </p>
+                                        <div className="space-y-2">
+                                                <h3 className="text-2xl font-semibold">{t("promo.whyTitle", "Miért a Hangakadémia®?")}</h3>
+                                                <p>{t("promo.benefit1", "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.")}</p>
+                                                <p>{t("promo.background1", "A Hangakadémia® nem csupán egy webshop.")}</p>
+                                                <p>
+                                                        {t(
+                                                                "promo.background2",
+                                                                "Minden hangtálat és hangszert személyesen válogatunk, kipróbálunk és szakmai szempontok alapján ajánlunk."
+                                                        )}
+                                                </p>
+                                                <p>
+                                                        {t(
+                                                                "promo.partnership",
+                                                                "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete."
+                                                        )}
+                                                </p>
+                                                <p>{t("promo.value", "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.")}</p>
+                                        </div>
+                                </div>
+                                <div className="text-center">
+                                        <Link to="https://hangakademia.hu" target="_blank" rel="noopener noreferrer">
+                                                <button className="bg-primary text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-primary/90 transition">
+                                                        {t("promo.cta", "👉 Ismerd meg a Hangakadémiát® és a Meinl Sonic Energy Magyarországi Nagykövetét")}
+                                                </button>
+                                        </Link>
+                                </div>
+                        </section>
 
 			{/* Categories Section */}
 			<section className="container py-16">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,32 +43,23 @@ const Index = () => {
                                 <h2 className="text-4xl font-bold mb-8 text-center">
                                         {t("promo.title", "HANGAKADÉMIA® – A hangok ereje a mindennapjaidban")}
                                 </h2>
-                                <div className="mb-8 text-lg text-gray-700 space-y-4 leading-relaxed">
-                                        <p>{t("promo.intro", "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.")}</p>
+                                <div className="mb-8 text-lg text-gray-700 space-y-2 leading-relaxed">
+                                        <h3 className="text-2xl font-semibold">{t("promo.whyTitle", "Miért a Hangakadémia®?")}</h3>
+                                        <p>{t("promo.benefit1", "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.")}</p>
+                                        <p>{t("promo.background1", "A Hangakadémia® nem csupán egy webshop.")}</p>
                                         <p>
                                                 {t(
-                                                        "promo.belief",
-                                                        "A Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet. Webshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással."
+                                                        "promo.background2",
+                                                        "Minden hangtálat és hangszert személyesen válogatunk, kipróbálunk és szakmai szempontok alapján ajánlunk."
                                                 )}
                                         </p>
-                                        <div className="space-y-2">
-                                                <h3 className="text-2xl font-semibold">{t("promo.whyTitle", "Miért a Hangakadémia®?")}</h3>
-                                                <p>{t("promo.benefit1", "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.")}</p>
-                                                <p>{t("promo.background1", "A Hangakadémia® nem csupán egy webshop.")}</p>
-                                                <p>
-                                                        {t(
-                                                                "promo.background2",
-                                                                "Minden hangtálat és hangszert személyesen válogatunk, kipróbálunk és szakmai szempontok alapján ajánlunk."
-                                                        )}
-                                                </p>
-                                                <p>
-                                                        {t(
-                                                                "promo.partnership",
-                                                                "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete."
-                                                        )}
-                                                </p>
-                                                <p>{t("promo.value", "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.")}</p>
-                                        </div>
+                                        <p>
+                                                {t(
+                                                        "promo.partnership",
+                                                        "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete."
+                                                )}
+                                        </p>
+                                        <p>{t("promo.value", "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.")}</p>
                                 </div>
                                 <div className="text-center">
                                         <Link to="https://hangakademia.hu" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- add FAQ section rendering on the About page with support for answers, lists, and external links
- populate the About translations with the provided Hungarian FAQ content across locales
- display FAQ cards in a responsive multi-column grid for better readability

## Testing
- npm run build *(fails: cannot resolve dependency react-toastify referenced in src/App.tsx)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948505228688332bf5415c67ae9e492)