### PR TITLE
Sync category slugs across pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,15 @@ function App() {
             />
           }
         />
-        <Route path="/products/:id" element={<ProductPage />} />
+        <Route
+          path="/products/:id"
+          element={
+            <ProductPage
+              onAddToCart={addProductsToCart}
+              setPageLoading={setPageLoading}
+            />
+          }
+        />
         <Route path="/categories" element={<Categories />} />
 
         <Route path="/cart" element={<Cart />} />

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,30 @@
+export type KnownCategory = {
+  slug: string;
+  name: string;
+  image?: string;
+};
+
+export const HOMEPAGE_CATEGORY_IMAGE = "/images/vizjeles_logo.webp";
+
+export const KNOWN_CATEGORIES: KnownCategory[] = [
+  { slug: "gongs-tam-tams", name: "Gongok" },
+  { slug: "hangvillak", name: "Hangvillák" },
+  { slug: "himalaja-tal", name: "Himalájai Hangtálak" },
+  { slug: "bowls", name: "Kristály Hangtálak és kelyhek" },
+  { slug: "calimbas", name: "Kalimbák" },
+  { slug: "handpans", name: "Handpanak" },
+  { slug: "accessory", name: "Kiegészítők" },
+  { slug: "drums", name: "Acél Nyelv Dobok" },
+  { slug: "main-drums", name: "Dobok" },
+  { slug: "chime", name: "Chimeok-Hangjátékok" },
+  { slug: "effects", name: "Hang effektek" },
+  { slug: "didgeridoo", name: "Didgeridoo" },
+  { slug: "energia-rudak", name: "Energia rudak" },
+  { slug: "tree-sound", name: "Üdők, dörzsfák" },
+  { slug: "bags-etc", name: "Táskák, tokok, huzatok" },
+  { slug: "stands", name: "Állványok" },
+];
+
+export const CATEGORY_ORDER_MAP = new Map(
+  KNOWN_CATEGORIES.map((category, index) => [category.slug, index] as const)
+);

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from "lucide-react";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { useTranslation } from "react-i18next";
+import { CATEGORY_ORDER_MAP, KNOWN_CATEGORIES } from "@/constants/categories";
 
 interface Category {
   id: number;
@@ -22,24 +23,9 @@ const hardcodedImages: Record<string, string> = {
   handpans: "https://zvukovaakademia.sk/wp-content/uploads/2025/09/handpan-stand.jpg",
 };
 
-const CATEGORY_ORDER = [
-  "Gongok",
-  "Hangvillák",
-  "Himalájai Hangtálak",
-  "Kristály Hangtálak és kelyhek",
-  "Kalimbák",
-  "Handpanak",
-  "Kiegészítők",
-  "Acél Nyelv Dobok",
-  "Dobok",
-  "Chimeok-Hangjátékok",
-  "Hang effektek",
-  "Didgeridoo",
-  "Energia rudak",
-  "Üdők, dörzsfák",
-  "Táskák, tokok, huzatok",
-  "Állványok",
-];
+const KNOWN_CATEGORY_BY_SLUG = new Map(
+  KNOWN_CATEGORIES.map((category) => [category.slug, category] as const)
+);
 
 const stripHtml = (html?: string) =>
   (html || "").replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
@@ -55,19 +41,15 @@ const normalize = (s: string) =>
     .replace(/[,/]/g, " ")
     .replace(/\s+/g, " ");
 
-const sortByCustomOrder = (cats: Category[]) => {
-  const orderMap = new Map<string, number>();
-  CATEGORY_ORDER.forEach((name, idx) => orderMap.set(normalize(name), idx));
-
-  return [...cats].sort((a, b) => {
-    const ai = orderMap.get(normalize(a.name));
-    const bi = orderMap.get(normalize(b.name));
+const sortByCustomOrder = (cats: Category[]) =>
+  [...cats].sort((a, b) => {
+    const ai = CATEGORY_ORDER_MAP.get(a.slug);
+    const bi = CATEGORY_ORDER_MAP.get(b.slug);
     if (ai !== undefined && bi !== undefined) return ai - bi;
     if (ai !== undefined) return -1;
     if (bi !== undefined) return 1;
-    return a.name.localeCompare(b.name, "hu");
+    return normalize(a.name).localeCompare(normalize(b.name), "hu");
   });
-};
 
 const sortAlphabeticalHU = (cats: Category[]) =>
   [...cats].sort((a, b) => a.name.localeCompare(b.name, "hu"));
@@ -102,10 +84,16 @@ const Categories = () => {
         const data: Category[] = await res.json();
         const allCats = data
           .filter((cat) => cat.slug !== "uncategorized")
-          .map((cat) => ({
-            ...cat,
-            image: { src: hardcodedImages[cat.slug] || cat.image?.src || placeholderImage },
-          }));
+          .map((cat) => {
+            const known = KNOWN_CATEGORY_BY_SLUG.get(cat.slug);
+            return {
+              ...cat,
+              name: known?.name || cat.name,
+              image: {
+                src: known?.image || hardcodedImages[cat.slug] || cat.image?.src || placeholderImage,
+              },
+            };
+          });
 
         setCategories(allCats);
         setError(null);

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -149,15 +149,9 @@ const Categories = () => {
 
   const handleCardClick = useCallback(
     (category: Category) => {
-      const hasSubs = categories?.some((c) => c.parent === category.id);
-      if (hasSubs) {
-        setCurrentParent(category);
-        setBreadcrumbs((prev) => [...prev, category]);
-      } else {
-        navigate(`/products?category=${category.slug}`);
-      }
+      navigate(`/products?category=${category.slug}`);
     },
-    [categories, navigate]
+    [navigate]
   );
 
   const handleBackClick = () => {

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -74,6 +74,15 @@ const Categories = () => {
   const auth = btoa(`${consumerKey}:${consumerSecret}`);
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const categoryParam = params.get("category");
+
+    if (categoryParam) {
+      navigate(`/products?category=${categoryParam}`);
+    }
+  }, [navigate]);
+
+  useEffect(() => {
     const fetchCategories = async () => {
       try {
         const res = await fetch(`${apiUrl}/products/categories?per_page=100`, {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/Footer";
 import { Facebook, Instagram, Music2, Youtube } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
+import { HOMEPAGE_CATEGORY_IMAGE, KNOWN_CATEGORIES } from "@/constants/categories";
 
 const socialLinks = [
   { name: "Facebook", icon: <Facebook className="h-5 w-5" />, url: "https://www.facebook.com/profile.php?id=100027587995370" },
@@ -17,24 +18,12 @@ const socialLinks = [
 const Index = () => {
   const { t } = useTranslation();
 
-  // Updated categories with the full curated order from the Categories page
-  const categories = [
-    { id: "gongok", slug: "gongok", title: "Gongok", image: "/images/vizjeles_logo.webp" },
-    { id: "hangvillak", slug: "hangvillak", title: "Hangvillák", image: "/images/vizjeles_logo.webp" },
-    { id: "himalajai-hangtalak", slug: "himalajai-hangtalak", title: "Himalájai Hangtálak", image: "/images/vizjeles_logo.webp" },
-    { id: "kristaly-hangtalak-es-kelyhek", slug: "kristaly-hangtalak-es-kelyhek", title: "Kristályhangtálak és kelyhek", image: "/images/vizjeles_logo.webp" },
-    { id: "kalimbak", slug: "kalimbak", title: "Kalimbák", image: "/images/vizjeles_logo.webp" },
-    { id: "handpanak", slug: "handpanak", title: "Handpanak", image: "/images/vizjeles_logo.webp" },
-    { id: "acel-nyelvdobok", slug: "acel-nyelvdobok", title: "Acél Nyelvdobok", image: "/images/vizjeles_logo.webp" },
-    { id: "dobok", slug: "dobok", title: "Dobok", image: "/images/vizjeles_logo.webp" },
-    { id: "chimeok-hangjatekok", slug: "chimeok-hangjatekok", title: "Chimeok-Hangjátékok", image: "/images/vizjeles_logo.webp" },
-    { id: "hang-effektek", slug: "hang-effektek", title: "Hang effektek", image: "/images/vizjeles_logo.webp" },
-    { id: "didgeridoo", slug: "didgeridoo", title: "Didgeridoo", image: "/images/vizjeles_logo.webp" },
-    { id: "energia-rudak", slug: "energia-rudak", title: "Energia rudak", image: "/images/vizjeles_logo.webp" },
-    { id: "udok-dorzsfak", slug: "udok-dorzsfak", title: "Üdők, dörzsfák", image: "/images/vizjeles_logo.webp" },
-    { id: "taskak-tokok-huzatok", slug: "taskak-tokok-huzatok", title: "Táskák, tokok, huzatok", image: "/images/vizjeles_logo.webp" },
-    { id: "allvanyok", slug: "allvanyok", title: "Állványok", image: "/images/vizjeles_logo.webp" },
-  ];
+  const categories = KNOWN_CATEGORIES.map((category) => ({
+    id: category.slug,
+    slug: category.slug,
+    title: category.name,
+    image: category.image || HOMEPAGE_CATEGORY_IMAGE,
+  }));
 
   return (
     <div className="min-h-screen bg-background flex flex-col">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -81,7 +81,7 @@ const Index = () => {
         <h2 className="text-3xl font-bold mb-8">{t("categories.title", "Válogass prémium kategóriáinkból")}</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
           {categories.map((category) => (
-            <Link key={category.id} to={`/products?category=${category.slug}`}>
+            <Link key={category.id} to={`/categories?category=${category.slug}`}>
               <CategoryCard {...category} />
             </Link>
           ))}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -3,6 +3,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { ProductCard } from "@/components/ProductCard";
 import { useTranslation } from "react-i18next";
+import { CATEGORY_ORDER_MAP, KNOWN_CATEGORIES } from "@/constants/categories";
 
 interface Product {
   id: number;
@@ -40,24 +41,6 @@ const VISIBLE_INCREMENT = 10;
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 const PRODUCT_CACHE_KEY = "woo_products_cache";
 const CATEGORY_CACHE_KEY = "woo_categories_cache";
-
-const CATEGORY_ORDER = [
-  "Gongok",
-  "Hangvillák",
-  "Himalájai Hangtálak",
-  "Kristály Hangtálak és kelyhek",
-  "Kalimbák",
-  "Handpanak",
-  "Acél Nyelv Dobok",
-  "Dobok",
-  "Chimeok-Hangjátékok",
-  "Hang effektek",
-  "Didgeridoo",
-  "Energia rudak",
-  "Üdők, dörzsfák",
-  "Táskák, tokok, huzatok",
-  "Állványok",
-];
 
 const WEIGHT_RANGES = [
   { key: "all", min: 0, max: Infinity },
@@ -126,6 +109,11 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     [t]
   );
 
+  const knownCategoryBySlug = useMemo(
+    () => new Map(KNOWN_CATEGORIES.map((category) => [category.slug, category] as const)),
+    []
+  );
+
   // ✅ FIX: keep only ONE selectedPriceRange (derived from selectedPriceRangeKey)
   const selectedPriceRange = useMemo(
     () => priceRanges.find((range) => range.key === selectedPriceRangeKey) ?? priceRanges[0],
@@ -174,12 +162,12 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
       const [first, ...rest] = list;
 
       const sortedRest = [...rest].sort((a, b) => {
-        const aIndex = CATEGORY_ORDER.findIndex((cat) => cat.toLowerCase() === a.label.toLowerCase());
-        const bIndex = CATEGORY_ORDER.findIndex((cat) => cat.toLowerCase() === b.label.toLowerCase());
+        const aIndex = CATEGORY_ORDER_MAP.get(a.key);
+        const bIndex = CATEGORY_ORDER_MAP.get(b.key);
 
-        if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-        if (aIndex !== -1) return -1;
-        if (bIndex !== -1) return 1;
+        if (aIndex !== undefined && bIndex !== undefined) return aIndex - bIndex;
+        if (aIndex !== undefined) return -1;
+        if (bIndex !== undefined) return 1;
         return a.label.localeCompare(b.label);
       });
 
@@ -211,7 +199,10 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
           setCategories(
             sortCategoriesByOrder([
               { key: "all", label: t("products.filters.all") || "All Categories" },
-              ...cachedCategories.map((cat) => ({ key: cat.slug, label: cat.name })),
+              ...cachedCategories.map((cat) => ({
+                key: cat.slug,
+                label: knownCategoryBySlug.get(cat.slug)?.name || cat.name,
+              })),
             ])
           );
         }
@@ -225,7 +216,10 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
         setCategories(
           sortCategoriesByOrder([
             { key: "all", label: t("products.filters.all") || "All Categories" },
-            ...data.map((cat) => ({ key: cat.slug, label: cat.name })),
+            ...data.map((cat) => ({
+              key: cat.slug,
+              label: knownCategoryBySlug.get(cat.slug)?.name || cat.name,
+            })),
           ])
         );
 
@@ -236,7 +230,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     };
 
     fetchCategories();
-  }, [apiUrl, auth, sortCategoriesByOrder, t]);
+  }, [apiUrl, auth, knownCategoryBySlug, sortCategoriesByOrder, t]);
 
   useEffect(() => {
     setCategories((prev) => sortCategoriesByOrder(prev));

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -71,10 +71,10 @@ const getCachedData = <T,>(key: string): T | null => {
   return null;
 };
 
-const setCache = <T,>(key: string, data: T) => {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(key, JSON.stringify({ timestamp: Date.now(), data }));
-};
+  const setCache = <T,>(key: string, data: T) => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(key, JSON.stringify({ timestamp: Date.now(), data }));
+  };
 
 type PriceRange = { key: string; label: string; min: number; max: number };
 
@@ -176,6 +176,10 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     [t]
   );
 
+  useEffect(() => {
+    setCategories((prev) => sortCategoriesByOrder(prev));
+  }, [sortCategoriesByOrder, t]);
+
   // Set category from URL or defaultCategory
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -232,10 +236,6 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     fetchCategories();
   }, [apiUrl, auth, knownCategoryBySlug, sortCategoriesByOrder, t]);
 
-  useEffect(() => {
-    setCategories((prev) => sortCategoriesByOrder(prev));
-  }, [sortCategoriesByOrder, t]);
-
   // Fetch products
   useEffect(() => {
     const fetchProducts = async () => {
@@ -291,23 +291,6 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
 
     fetchProducts();
   }, [apiUrl, auth, setPageLoading, t]);
-
-  useEffect(() => {
-    setCategories((prev) => {
-      if (!prev.length) return prev;
-      const [, ...rest] = prev;
-      const sortedRest = rest.sort((a, b) => {
-        const aIndex = CATEGORY_ORDER.findIndex((cat) => cat.toLowerCase() === a.label.toLowerCase());
-        const bIndex = CATEGORY_ORDER.findIndex((cat) => cat.toLowerCase() === b.label.toLowerCase());
-
-        if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-        if (aIndex !== -1) return -1;
-        if (bIndex !== -1) return 1;
-        return a.label.localeCompare(b.label);
-      });
-      return [{ ...prev[0], label: t("products.filters.all") || prev[0].label }, ...sortedRest];
-    });
-  }, [t]);
 
   // Filtering logic
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add a shared category constant with the provided slugs and names
- drive the homepage, categories grid, and products filter labels from the shared slugs to keep navigation aligned
- order categories consistently using the shared slug map so category clicks open matching product filters

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948751518b483329629c143c6b02cc4)