### PR TITLE
Fix product page pricing and cart handling

### DIFF
--- a/src/MyStoreContext.tsx
+++ b/src/MyStoreContext.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
+import { formatWooPrice } from "@/lib/currency";
 
 // --- Types ---
 interface Product {
@@ -70,13 +71,14 @@ export const MyStoreProvider: React.FC<{ children: ReactNode }> = ({ children })
       return (
         <>
           <span className="text-muted text-decoration-line-through">
-            ${product.regular_price}
+            {formatWooPrice(parseFloat(product.regular_price || product.price || "0"))}
           </span>{" "}
-          <span className="text-danger">${product.sale_price}</span>
+          <span className="text-danger">{formatWooPrice(parseFloat(product.sale_price))}</span>
         </>
       );
     }
-    return <>{`$${product.regular_price || product.price}`}</>;
+    const priceValue = parseFloat(product.regular_price || product.price || "0");
+    return <>{formatWooPrice(priceValue)}</>;
   };
 
   const setUserLoggedInStatus = (status: boolean) => {

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 import { Card, CardFooter, CardHeader, CardContent, CardTitle } from "./ui/card";
+import { formatWooPrice } from "@/lib/currency";
 
 type ProductCardProps = {
   id: string;
@@ -38,7 +39,7 @@ export const ProductCard = ({
       </CardHeader>
       <CardContent className="p-4">
         <CardTitle className="text-lg font-medium line-clamp-2">{title}</CardTitle>
-        <p className="text-2xl font-bold mt-2">€{price.toFixed(2)}</p>
+        <p className="text-2xl font-bold mt-2">{formatWooPrice(price)}</p>
         {available && <p className="text-green-500 text-sm mt-1">{t("products.filters.stockAvailable")}</p>}
         {description && (
           <p

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,17 @@
+const DEFAULT_CURRENCY = import.meta.env.VITE_WOO_CURRENCY || "HUF";
+const DEFAULT_LOCALE = import.meta.env.VITE_WOO_CURRENCY_LOCALE || "hu-HU";
+
+export const formatWooPrice = (value: number) => {
+  try {
+    return new Intl.NumberFormat(DEFAULT_LOCALE, {
+      style: "currency",
+      currency: DEFAULT_CURRENCY,
+      maximumFractionDigits: DEFAULT_CURRENCY === "HUF" ? 0 : 2,
+    }).format(value);
+  } catch {
+    const symbol = DEFAULT_CURRENCY === "HUF" ? "Ft" : DEFAULT_CURRENCY;
+    return `${value.toFixed(DEFAULT_CURRENCY === "HUF" ? 0 : 2)} ${symbol}`;
+  }
+};
+
+export const wooCurrencyCode = DEFAULT_CURRENCY;

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -15,11 +15,12 @@ interface Product {
   description?: string;
   short_description?: string;
   stock_status?: string;
-  images: { id: number; src: string }[];
+  images?: { id?: number; src: string }[];
   attributes?: { id: number; name: string; options: string[] }[];
   meta_data?: { key: string; value: string }[];
   categories?: { id: number; name: string; slug: string }[];
   quantity?: number; // for cart
+  [key: string]: unknown; // keep compatible with MyStoreContext
 }
 
 interface Variation {

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
+import { formatWooPrice } from "@/lib/currency";
+import { useMyStore } from "@/MyStoreContext";
 
 interface Product {
   id: number;
@@ -40,16 +42,10 @@ const stripHtml = (html?: string) => {
   return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
 };
 
-const moneyHuf = (n: number) =>
-  new Intl.NumberFormat("hu-HU", {
-    style: "currency",
-    currency: "HUF",
-    maximumFractionDigits: 0,
-  }).format(n);
-
 const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { addProductsToCart } = useMyStore();
 
   const consumerKey = import.meta.env.VITE_WOO_CONSUMER_KEY;
   const consumerSecret = import.meta.env.VITE_WOO_CONSUMER_SECRET;
@@ -81,6 +77,8 @@ const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
     const v = selectedVariation?.price;
     return parseFloat(v ?? base ?? "0");
   }, [product, selectedVariation]);
+
+  const formatPrice = useCallback((price: number) => formatWooPrice(price), []);
 
   const inStock = useMemo(() => {
     if (!product) return false;
@@ -208,13 +206,9 @@ const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
       ],
     };
 
-    if (typeof onAddToCart === "function") {
-      onAddToCart(cartProduct);
-    } else {
-      // If route didn’t pass handler, don’t silently fail
-      alert("A kosár funkció nincs bekötve ehhez az oldalhoz (onAddToCart hiányzik).");
-    }
-  }, [product, canAddToCart, qty, displayPrice, displayImage, isVariable, selectedVariation, onAddToCart]);
+    const cartHandler = onAddToCart || addProductsToCart;
+    cartHandler(cartProduct);
+  }, [product, canAddToCart, qty, displayPrice, displayImage, isVariable, selectedVariation, onAddToCart, addProductsToCart]);
 
   if (loading) {
     return (
@@ -273,7 +267,7 @@ const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
             <div className="flex flex-col gap-4">
               <h1 className="text-3xl font-bold">{product.name}</h1>
 
-              <div className="text-2xl font-semibold">€{displayPrice.toFixed(2)}</div>
+              <div className="text-2xl font-semibold">{formatPrice(displayPrice)}</div>
 
               <div className={`text-sm font-medium ${inStock ? "text-green-600" : "text-red-600"}`}>
                 {inStock ? "Készleten" : isVariable && !selectedVariation ? "Válassz változatot" : "Nincs készleten"}
@@ -315,7 +309,7 @@ const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
                       const stock = v.stock_status === "instock" ? "Készleten" : "Nincs készleten";
                       return (
                         <option key={v.id} value={v.id}>
-                          {attrs} — €{price.toFixed(2)} — {stock}
+                          {attrs} — {formatPrice(price)} — {stock}
                         </option>
                       );
                     })}
@@ -342,7 +336,7 @@ const ProductPage = ({ onAddToCart, setPageLoading }: ProductPageProps) => {
                   </button>
                 </div>
 
-                <div className="text-sm text-foreground/70">Ingyenes szállítás: {moneyHuf(30000)} felett</div>
+                <div className="text-sm text-foreground/70">Ingyenes szállítás: {formatPrice(30000)} felett</div>
               </div>
 
               {/* Add */}


### PR DESCRIPTION
## Summary
- add a shared WooCommerce currency formatter and apply it to product list cards and the detailed product page
- ensure the product detail page can fall back to the store cart handler so add-to-cart works reliably
- update store price rendering to respect the configured WooCommerce currency instead of hard-coded dollars/euros

## Testing
- npm run build *(fails: unable to download react-toastify from npm registry in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490aac8f3c8332bb2bf7f52b09e837)