### PR TITLE
Fetch all WooCommerce items for search

### DIFF
--- a/public/images/sonic-energy-logo.svg
+++ b/public/images/sonic-energy-logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 280" role="img" aria-labelledby="title desc">
+  <title id="title">Meinl Sonic Energy Collection Logo</title>
+  <desc id="desc">Stylized Meinl Sonic Energy Collection wordmark in gold.</desc>
+  <defs>
+    <linearGradient id="gold" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#c7942c" />
+      <stop offset="100%" stop-color="#b17a1d" />
+    </linearGradient>
+  </defs>
+  <g fill="url(#gold)" stroke="none">
+    <path d="M86 78c0-26 18-44 43-44 19 0 30 10 36 20 8-10 19-20 38-20 25 0 43 18 43 44v81h-30V90c0-10-6-18-16-18s-17 8-17 18v69h-28V90c0-10-7-18-17-18s-16 8-16 18v69H86z"/>
+    <path d="M193 60c6-10 17-20 36-20 25 0 43 18 43 44v81h-30V90c0-10-6-18-16-18-9 0-15 7-16 16l-17-28z" opacity="0.3"/>
+  </g>
+  <g fill="#b6862c" font-family="" text-anchor="middle">
+    <text x="180" y="185" font-size="48" font-weight="600" font-family="" font-style="normal" letter-spacing="1">Sonic Energy</text>
+    <rect x="86" y="198" width="188" height="2" fill="#b6862c" />
+    <text x="180" y="232" font-size="26" font-weight="500">Collection</text>
+  </g>
+</svg>

--- a/src/MyStoreContext.tsx
+++ b/src/MyStoreContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import { toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
+import { DEFAULT_CURRENCY, formatMoney, getCurrencyInfo } from "@/utils/currency";
 
 // --- Types ---
 interface Product {
@@ -18,6 +19,11 @@ interface Product {
   sale_price?: string;
   quantity?: number;
   images?: { src: string }[];
+  currency?: string;
+  currency_code?: string;
+  currency_symbol?: string;
+  prices?: { currency_code?: string; currency_symbol?: string };
+  meta_data?: { key: string; value: unknown }[];
   [key: string]: unknown;
 }
 
@@ -49,6 +55,8 @@ interface MyStoreContextType {
     product_id: number | string;
     quantity?: number;
     variants?: Record<string, string>;
+    currencyCode?: string;
+    currencySymbol?: string;
   }) => void;
 }
 
@@ -67,17 +75,22 @@ export const MyStoreProvider: React.FC<{ children: ReactNode }> = ({ children })
   const setPageLoading = useCallback((status: boolean) => setLoader(status), []);
 
   const renderProductPrice = (product: Product): JSX.Element => {
-    if (product.sale_price) {
+    const currency = getCurrencyInfo(product);
+    const regular = parseFloat((product.regular_price ?? product.price ?? "0").toString());
+    const sale = product.sale_price ? parseFloat(product.sale_price.toString()) : undefined;
+
+    if (sale !== undefined) {
       return (
         <>
           <span className="text-muted text-decoration-line-through">
-            ${product.regular_price}
+            {formatMoney(regular, currency)}
           </span>{" "}
-          <span className="text-danger">${product.sale_price}</span>
+          <span className="text-danger">{formatMoney(sale, currency)}</span>
         </>
       );
     }
-    return <>{`$${product.regular_price || product.price}`}</>;
+
+    return <>{formatMoney(regular, currency)}</>;
   };
 
   const setUserLoggedInStatus = (status: boolean) => {
@@ -100,15 +113,26 @@ export const MyStoreProvider: React.FC<{ children: ReactNode }> = ({ children })
   const addProductsToCart = useCallback((product: Product) => {
     const cartFromStorage: Product[] = JSON.parse(localStorage.getItem("cart") || "[]");
 
-    const existingIndex = cartFromStorage.findIndex((item) => item.id === product.id);
+    const currency = getCurrencyInfo(product);
+    const normalizedQuantity =
+      typeof product.quantity === "number" && product.quantity > 0 ? product.quantity : 1;
+    const normalizedProduct: Product = {
+      ...product,
+      currency: product.currency || currency.code,
+      currency_symbol: product.currency_symbol || currency.symbol,
+      prices: product.prices || { currency_code: currency.code, currency_symbol: currency.symbol },
+      quantity: normalizedQuantity,
+    };
+
+    const existingIndex = cartFromStorage.findIndex((item) => item.id === normalizedProduct.id);
     const updatedCart = [...cartFromStorage];
 
     if (existingIndex >= 0) {
       const existing = { ...updatedCart[existingIndex] };
-      existing.quantity = (existing.quantity || 1) + (product.quantity || 1);
+      existing.quantity = (existing.quantity || 1) + normalizedQuantity;
       updatedCart[existingIndex] = existing;
     } else {
-      updatedCart.push({ ...product, quantity: product.quantity || 1 });
+      updatedCart.push(normalizedProduct);
     }
 
     setCart(updatedCart);
@@ -136,14 +160,20 @@ export const MyStoreProvider: React.FC<{ children: ReactNode }> = ({ children })
       product_id: number | string;
       quantity?: number;
       variants?: Record<string, string>;
+      currencyCode?: string;
+      currencySymbol?: string;
     }) => {
+      const currencyCode = item.currencyCode || DEFAULT_CURRENCY.code;
       const productToAdd: Product = {
         id: Number(item.product_id),
         name: item.title,
         regular_price: item.price.toString(),
         quantity: item.quantity || 1,
         images: [{ src: item.image }],
-        price: ""
+        price: "",
+        currency: currencyCode,
+        currency_symbol: item.currencySymbol,
+        prices: { currency_code: currencyCode, currency_symbol: item.currencySymbol }
       };
       addProductsToCart(productToAdd);
     },

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,7 +43,7 @@ export const Navbar = () => {
             <img
               src="/images/PalAdri-logo-light.png"
               alt="Hangakadémia logó"
-              className="h-16 md:h-20 w-auto"
+              className="h-20 md:h-24 w-auto"
             />
           </div>
     
@@ -73,7 +73,7 @@ export const Navbar = () => {
             <img
               src="/images/sonic-energy-logo.svg"
               alt="Sonic Energy Collection logó"
-              className="hidden sm:block h-12 w-auto"
+              className="hidden sm:block h-14 md:h-16 w-auto"
             />
             <LanguageSwitcher />
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -42,7 +42,7 @@ export const Navbar = () => {
           >
             <img
               src="/images/PalAdri-logo-light.png"
-              alt="Hangakadémia logó"
+              alt="HangAkadémia logó"
               className="h-20 md:h-24 w-auto"
             />
           </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -37,16 +37,15 @@ export const Navbar = () => {
         <div className="flex items-center justify-between">
           {/* Logo */}
           <div
-  className="cursor-pointer flex items-center"
-  onClick={() => navigate('/')}
->
-  <img
-    src="/images/PalAdri-logo-light.png"
-    alt="Hangakadémia logó"
-    className="h-30 w-auto"
-    style={{ maxHeight: 80 }}
-  />
-</div>
+            className="cursor-pointer flex items-center"
+            onClick={() => navigate('/')}
+          >
+            <img
+              src="/images/PalAdri-logo-light.png"
+              alt="Hangakadémia logó"
+              className="h-16 md:h-20 w-auto"
+            />
+          </div>
     
 
           {/* Mobile menu button */}
@@ -62,15 +61,20 @@ export const Navbar = () => {
 
           {/* Desktop nav links */}
           <div className="hidden md:flex items-center space-x-6">
-  <Link to="/" className="text-primary hover:text-secondary transition-colors">{t('navbar.home')}</Link>
-  <Link to="/categories" className="text-primary hover:text-secondary transition-colors">{t('navbar.products')}</Link>
-  <Link to="/about" className="text-primary hover:text-secondary transition-colors">{t('navbar.about')}</Link>
-  <Link to="/contact" className="text-primary hover:text-secondary transition-colors">{t('navbar.contact')}</Link>
-</div>
+            <Link to="/" className="text-primary hover:text-secondary transition-colors">{t('navbar.home')}</Link>
+            <Link to="/categories" className="text-primary hover:text-secondary transition-colors">{t('navbar.products')}</Link>
+            <Link to="/about" className="text-primary hover:text-secondary transition-colors">{t('navbar.about')}</Link>
+            <Link to="/contact" className="text-primary hover:text-secondary transition-colors">{t('navbar.contact')}</Link>
+          </div>
 
 
           {/* Right controls: Language, Cart, Auth (login/logout and new pages) */}
           <div className="flex items-center space-x-4">
+            <img
+              src="/images/sonic-energy-logo.svg"
+              alt="Sonic Energy Collection logó"
+              className="hidden sm:block h-12 w-auto"
+            />
             <LanguageSwitcher />
 
             <Link

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,7 +43,7 @@ export const Navbar = () => {
             <img
               src="/images/PalAdri-logo-light.png"
               alt="HangAkadémia logó"
-              className="h-20 md:h-24 w-auto"
+              className="h-20 md:h-32 lg:h-40 w-auto"
             />
           </div>
     

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 import { Card, CardFooter, CardHeader, CardContent, CardTitle } from "./ui/card";
+import { CurrencyInfo, formatMoney } from "@/utils/currency";
 
 type ProductCardProps = {
   id: string;
@@ -12,6 +13,7 @@ type ProductCardProps = {
   available?: boolean;
   description?: string;
   onAddToCart: () => void;
+  currency?: CurrencyInfo;
 };
 
 export const ProductCard = ({
@@ -22,8 +24,11 @@ export const ProductCard = ({
   available = true,
   description,
   onAddToCart,
+  currency,
 }: ProductCardProps) => {
   const { t } = useTranslation();
+
+  const formattedPrice = currency ? formatMoney(price, currency) : `€${price.toFixed(2)}`;
 
   return (
     <Card className="overflow-hidden group transition-all duration-300 hover:shadow-lg relative">
@@ -38,7 +43,7 @@ export const ProductCard = ({
       </CardHeader>
       <CardContent className="p-4">
         <CardTitle className="text-lg font-medium line-clamp-2">{title}</CardTitle>
-        <p className="text-2xl font-bold mt-2">€{price.toFixed(2)}</p>
+        <p className="text-2xl font-bold mt-2">{formattedPrice}</p>
         {available && <p className="text-green-500 text-sm mt-1">{t("products.filters.stockAvailable")}</p>}
         {description && (
           <p

--- a/src/hooks/useProductSuggestions.ts
+++ b/src/hooks/useProductSuggestions.ts
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+interface ProductSuggestion {
+  id: number;
+  name: string;
+  price?: string;
+  images?: { id: number; src: string }[];
+}
+
+interface UseProductSuggestionsResult {
+  suggestions: ProductSuggestion[];
+  loading: boolean;
+  error: string;
+  hasNoResults: boolean;
+}
+
+const createAuthHeader = () => {
+  const consumerKey = import.meta.env.VITE_WOO_CONSUMER_KEY;
+  const consumerSecret = import.meta.env.VITE_WOO_CONSUMER_SECRET;
+  const apiUrl = import.meta.env.VITE_WOO_API_URL;
+
+  return {
+    authHeader: btoa(`${consumerKey}:${consumerSecret}`),
+    apiUrl,
+  };
+};
+
+export const useProductSuggestions = (
+  rawSearchTerm: string,
+  minimumLength = 2
+): UseProductSuggestionsResult => {
+  const searchTerm = rawSearchTerm.trim();
+  const controllerRef = useRef<AbortController | null>(null);
+  const [{ suggestions, loading, error }, setState] = useState<{
+    suggestions: ProductSuggestion[];
+    loading: boolean;
+    error: string;
+  }>({ suggestions: [], loading: false, error: "" });
+
+  const { authHeader, apiUrl } = useMemo(createAuthHeader, []);
+
+  useEffect(() => {
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
+
+    if (searchTerm.length < minimumLength) {
+      setState({ suggestions: [], loading: false, error: "" });
+      return;
+    }
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    const fetchSuggestions = async () => {
+      setState((prev) => ({ ...prev, loading: true, error: "" }));
+      try {
+        const res = await fetch(
+          `${apiUrl}/products?per_page=8&search=${encodeURIComponent(searchTerm)}`,
+          {
+            signal: controller.signal,
+            headers: { Authorization: `Basic ${authHeader}` },
+          }
+        );
+
+        if (!res.ok) {
+          throw new Error(`Failed to fetch suggestions for "${searchTerm}"`);
+        }
+
+        const data: ProductSuggestion[] = await res.json();
+        setState({ suggestions: data, loading: false, error: "" });
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setState({ suggestions: [], loading: false, error: (err as Error).message });
+      }
+    };
+
+    void fetchSuggestions();
+
+    return () => controller.abort();
+  }, [apiUrl, authHeader, minimumLength, searchTerm]);
+
+  return {
+    suggestions,
+    loading,
+    error,
+    hasNoResults: !loading && searchTerm.length >= minimumLength && suggestions.length === 0,
+  };
+};

--- a/src/hooks/useProductSuggestions.ts
+++ b/src/hooks/useProductSuggestions.ts
@@ -1,10 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { KNOWN_CATEGORIES } from "@/constants/categories";
+
+type SuggestionType = "product" | "category";
+
 interface ProductSuggestion {
-  id: number;
+  id: string;
   name: string;
   price?: string;
   images?: { id: number; src: string }[];
+  type: SuggestionType;
+  slug?: string;
 }
 
 interface UseProductSuggestionsResult {
@@ -67,8 +73,30 @@ export const useProductSuggestions = (
           throw new Error(`Failed to fetch suggestions for "${searchTerm}"`);
         }
 
-        const data: ProductSuggestion[] = await res.json();
-        setState({ suggestions: data, loading: false, error: "" });
+        const data = (await res.json()) as { id: number; name: string; price?: string }[];
+
+        const productSuggestions: ProductSuggestion[] = data.map((item) => ({
+          id: item.id.toString(),
+          name: item.name,
+          price: item.price,
+          type: "product",
+        }));
+
+        const normalizedTerm = searchTerm.toLowerCase();
+        const categorySuggestions: ProductSuggestion[] = KNOWN_CATEGORIES.filter((category) =>
+          category.name.toLowerCase().includes(normalizedTerm)
+        ).map((category) => ({
+          id: `category-${category.slug}`,
+          name: category.name,
+          type: "category",
+          slug: category.slug,
+        }));
+
+        setState({
+          suggestions: [...categorySuggestions, ...productSuggestions],
+          loading: false,
+          error: "",
+        });
       } catch (err) {
         if ((err as Error).name === "AbortError") return;
         setState({ suggestions: [], loading: false, error: (err as Error).message });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -142,6 +142,8 @@
     "action": "Aktion",
     "noItems": "Keine Artikel im Warenkorb.",
     "remove": "Entfernen",
+    "itemsSection": "Artikel in deinem Warenkorb",
+    "reviewItems": "Überprüfe unten deine Artikel",
     "total": "Gesamt",
     "checkout": "Zur Kasse",
     "processing": "Wird verarbeitet...",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -150,6 +150,7 @@
     "addToCart": "In den Warenkorb",
     "addedToCart": "Hinzugefügt",
     "addedDescription": "{{title}} wurde Ihrem Warenkorb hinzugefügt.",
+    "secureStripe": "Sichere Zahlung über Stripe",
     "removeConfirm": "Möchten Sie diesen Artikel wirklich entfernen?",
     "removed": "Produkt aus dem Warenkorb entfernt!"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -144,6 +144,8 @@
     "items": "{{count}} items",
     "empty": "Your cart is empty",
     "clearAll": "Clear All",
+    "itemsSection": "Items in your cart",
+    "reviewItems": "Review your items below",
     "total": "Total",
     "checkout": "Proceed to Checkout",
     "addToCart": "Add to Cart",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -133,6 +133,14 @@
   },
   "cart": {
     "title": "Shopping Cart",
+    "emptyMessage": "Your cart is empty.",
+    "image": "Image",
+    "product": "Product",
+    "unitPrice": "Unit Price",
+    "quantity": "Quantity",
+    "action": "Action",
+    "noItems": "There are no items in your cart.",
+    "remove": "Remove",
     "items": "{{count}} items",
     "empty": "Your cart is empty",
     "clearAll": "Clear All",
@@ -140,7 +148,11 @@
     "checkout": "Proceed to Checkout",
     "addToCart": "Add to Cart",
     "addedToCart": "Added to Cart",
-    "addedDescription": "{{title}} has been added to your cart."
+    "addedDescription": "{{title}} has been added to your cart.",
+    "processing": "Processing...",
+    "secureStripe": "Secure checkout powered by Stripe",
+    "removeConfirm": "Are you sure you want to remove this item?",
+    "removed": "Product removed from Cart!"
   },
   "about": {
     "title": "A HangAkadémia® – ahol a hang tudássá válik",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -144,6 +144,8 @@
     "action": "Művelet",
     "noItems": "Nincsenek tételek a kosárban.",
     "remove": "Eltávolítás",
+    "itemsSection": "Kosárban lévő termékek",
+    "reviewItems": "Ellenőrizd az alábbi tételeket",
     "total": "Összesen",
     "checkout": "Tovább a fizetéshez",
     "processing": "Feldolgozás...",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -1,5 +1,5 @@
 {
-  "site": "Hangakadémia",
+  "site": "HangAkadémia",
   "navbar": {
     "home": "Főoldal",
     "products": "Termékek",
@@ -11,9 +11,9 @@
     "loginSignup": "Bejelentkezés / Regisztráció"
   },
   "hero": {
-    "title": "Hangakadémia® a hangok ereje a mindennapjaidban",
-    "subtitle": "Merülj el a hangok gyógyító rezgésében.",
-    "description": "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.\n\nA Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet.\nWebshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással.",
+    "title": "HangAkadémia® a hangok ereje a mindennapjaidban",
+    "subtitle": "Merülj el a hangok harmonizáló rezgésében.",
+    "description": "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.\n\nA HangAkadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet.\nWebshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással.",
     "imageAlt": "Hangterápiás hangszerek"
   },
   "categories": {
@@ -31,8 +31,8 @@
     "stands": "Állványok"
   },
   "products": {
-    "title": "Hanggyógyító hangszerek",
-    "subtitle": "Fedezd fel gondosan összeválogatott prémium hanggyógyító hangszereink kollekcióját. Minden darab harmóniát, békét és gyógyító rezgéseket hoz az életedbe.",
+    "title": "Hangélményt adó hangszerek",
+    "subtitle": "Fedezd fel gondosan összeválogatott prémium hangszereink kollekcióját. Minden darab harmóniát és békét hoz az életedbe.",
     "featured": "Kiemelt termékek",
     "search": "Hangszerek keresése...",
     "filters": {
@@ -210,7 +210,7 @@
           },
           {
             "title": "Oktatási háttér",
-            "description": "A Hangakadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
+            "description": "A HangAkadémia® mögött aktív oktatási tevékenység áll. Online és személyes képzéseinken strukturált rendszerben adjuk át a hangszerek tudatos használatához szükséges ismereteket."
           },
           {
             "title": "Prémium minőség és biztonság",
@@ -219,7 +219,7 @@
         ]
       },
       {
-        "title": "A Hangakadémia® szemlélete",
+        "title": "A HangAkadémia® szemlélete",
         "paragraphs": [
           "A HangAkadémiánál® a hang egyszerre élmény és minőség.",
           "Lehet önfeledt, lehet elmélyítő, lehet inspiráló – számunkra azonban mindig fontos, hogyan szólal meg, milyen minőséget képvisel, és milyen kapcsolatot teremt az ember és a hangszer között.",
@@ -497,11 +497,11 @@
       "title": "HANGAKADÉMIA® – A hangok ereje a mindennapjaidban",
       "intro": "Fedezd fel a hangtálak, hangszerek és rezgésalapú hangélmények különleges világát.",
       "belief": "A Hangakadémiánál® hiszünk abban, hogy a hang tudatos használata támogatja a belső egyensúlyt, a nyugalmat és a mélyebb jelenlétet. Webshopunkban gondosan válogatott Himalájai hangtálakat, professzionális Meinl Sonic Energy hangszereket és prémium kiegészítőket találsz – minden darabot személyesen kipróbálva, szakmai ajánlással.",
-      "whyTitle": "Miért a Hangakadémia®?",
+      "whyTitle": "Miért a HangAkadémia®?",
       "benefit1": "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.",
-      "background1": "A Hangakadémia® nem csupán egy webshop.",
+      "background1": "A HangAkadémia® nem csupán egy webshop.",
       "background2": "Minden hangtálat és hangszert személyesen válogatunk, kipróbálunk és szakmai szempontok alapján ajánlunk.",
-      "partnership": "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete.",
+      "partnership": "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete.",
       "value": "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.",
       "cta": "👉 Ismerd meg a Hangakadémiát® és a Meinl Sonic Energy Magyarországi Nagykövetét"
     }

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -152,6 +152,7 @@
     "addToCart": "Kosárba",
     "addedToCart": "Kosárba helyezve",
     "addedDescription": "{{title}} hozzáadva a kosárhoz.",
+    "secureStripe": "Biztonságos fizetés Stripe-pal",
     "removeConfirm": "Biztos törli a tételt?",
     "removed": "A termék eltávolítva a kosárból!"
   },

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -142,6 +142,8 @@
     "action": "Akcia",
     "noItems": "Žiadne položky v košíku.",
     "remove": "Odstrániť",
+    "itemsSection": "Položky vo vašom košíku",
+    "reviewItems": "Skontrolujte nižšie svoje položky",
     "total": "Celkom",
     "checkout": "Pokračovať k pokladni",
     "processing": "Spracováva sa...",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -150,6 +150,7 @@
     "addToCart": "Pridať do košíka",
     "addedToCart": "Pridané do košíka",
     "addedDescription": "{{title}} bol pridaný do vášho košíka.",
+    "secureStripe": "Bezpečná platba cez Stripe",
     "removeConfirm": "Naozaj chcete túto položku odstrániť?",
     "removed": "Produkt bol odstránený z košíka!"
   },

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -104,7 +104,7 @@ const Cart = () => {
                   <th className="p-3 border-b">{t("cart.image")}</th>
                   <th className="p-3 border-b">{t("cart.product")}</th>
                   <th className="p-3 border-b">{t("cart.unitPrice")}</th>
-                  <th className="p-3 border-b">{t("cart.quantity")}</th>
+                  <th className="p-3 border-b text-center">{t("cart.quantity")}</th>
                   <th className="p-3 border-b">{t("cart.action")}</th>
                 </tr>
               </thead>
@@ -135,7 +135,7 @@ const Cart = () => {
                   <th className="p-3 border-b">{t("cart.image")}</th>
                   <th className="p-3 border-b">{t("cart.product")}</th>
                   <th className="p-3 border-b">{t("cart.unitPrice")}</th>
-                  <th className="p-3 border-b">{t("cart.quantity")}</th>
+                  <th className="p-3 border-b text-center">{t("cart.quantity")}</th>
                   <th className="p-3 border-b">{t("cart.action")}</th>
                 </tr>
               </thead>
@@ -149,10 +149,25 @@ const Cart = () => {
                         className="w-12 h-12 object-cover rounded"
                       />
                     </td>
-                    <td className="p-3">{item.name}</td>
-                    <td className="p-3">{renderProductPrice(item)}</td>
-                    <td className="p-3">{item.quantity || 1}</td>
                     <td className="p-3">
+                      <div className="flex items-center justify-between sm:block">
+                        <span>{item.name}</span>
+                        <button
+                          onClick={() =>
+                            removeItemsFromCart({
+                              ...item,
+                              price: item.price.toString(),
+                            })
+                          }
+                          className="text-red-600 hover:text-red-800 sm:hidden ml-2"
+                        >
+                          {t("cart.remove")}
+                        </button>
+                      </div>
+                    </td>
+                    <td className="p-3">{renderProductPrice(item)}</td>
+                    <td className="p-3 text-center">{item.quantity || 1}</td>
+                    <td className="p-3 hidden sm:table-cell">
                       <button
                         onClick={() =>
                           removeItemsFromCart({

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useMyStore } from "@/MyStoreContext";
@@ -6,6 +6,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer"; // <-- import Footer
 import { FaRegFrown } from "react-icons/fa";
 import { toast } from "react-toastify";
+import { DEFAULT_CURRENCY, formatMoney, getCurrencyInfo } from "@/utils/currency";
 
 interface Product {
   id: number;
@@ -15,6 +16,12 @@ interface Product {
   sale_price?: string;
   quantity?: number;
   images?: { src: string }[];
+  currency?: string;
+  currency_symbol?: string;
+  currency_code?: string;
+  prices?: { currency_code?: string; currency_symbol?: string };
+  price_html?: string;
+  meta_data?: { key: string; value: unknown }[];
   [key: string]: unknown;
 }
 
@@ -28,6 +35,17 @@ const Cart = () => {
   useEffect(() => {
     setCartItems(cart || []);
   }, [cart]);
+
+  const cartCurrency = useMemo(
+    () => (cartItems.length ? getCurrencyInfo(cartItems[0]) : DEFAULT_CURRENCY),
+    [cartItems]
+  );
+
+  const parsePrices = (product: Product) => {
+    const regular = parseFloat((product.regular_price ?? product.price ?? "0").toString());
+    const sale = product.sale_price ? parseFloat(product.sale_price.toString()) : undefined;
+    return { regular, sale };
+  };
 
   const handleStripeCheckout = () => {
     if (!isAuthenticated) {
@@ -44,39 +62,30 @@ const Cart = () => {
   };
 
   const renderProductPrice = (product: Product) => {
-    const regular = parseFloat(
-      (product.regular_price ?? product.price ?? "0").toString()
-    );
-    const sale = product.sale_price
-      ? parseFloat(product.sale_price.toString())
-      : undefined;
+    const { regular, sale } = parsePrices(product);
+    const currency = getCurrencyInfo(product);
 
     return sale !== undefined ? (
       <>
         <span className="line-through text-gray-400 mr-2">
-          {regular.toFixed(2)} €
+          {formatMoney(regular, currency)}
         </span>
-        <span className="text-red-600">{sale.toFixed(2)} €</span>
+        <span className="text-red-600">{formatMoney(sale, currency)}</span>
       </>
     ) : (
-      <>{regular.toFixed(2)} €</>
+      <>{formatMoney(regular, currency)}</>
     );
   };
 
   const calculateTotalItemsPrice = () => {
-    return cartItems
-      .reduce((total, item) => {
-        const regular = parseFloat(
-          (item.regular_price ?? item.price ?? "0").toString()
-        );
-        const sale = item.sale_price
-          ? parseFloat(item.sale_price.toString())
-          : undefined;
-        const price = sale !== undefined ? sale : regular;
-        const quantity = item.quantity || 1;
-        return total + price * quantity;
-      }, 0)
-      .toFixed(2);
+    const total = cartItems.reduce((current, item) => {
+      const { regular, sale } = parsePrices(item);
+      const price = sale !== undefined ? sale : regular;
+      const quantity = item.quantity || 1;
+      return current + price * quantity;
+    }, 0);
+
+    return formatMoney(total, cartCurrency);
   };
 
   return (
@@ -152,9 +161,17 @@ const Cart = () => {
             </table>
 
             <div className="flex flex-col sm:flex-row sm:justify-between items-start sm:items-center mt-6 gap-4">
-              <h3 className="text-xl font-semibold">
-                {t("cart.total")}: {calculateTotalItemsPrice()} €
-              </h3>
+              <div className="flex flex-col gap-1">
+                <h3 className="text-xl font-semibold">
+                  {t("cart.total")}: {calculateTotalItemsPrice()}
+                </h3>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 text-indigo-700 font-semibold border border-indigo-100">
+                    Stripe
+                  </span>
+                  <span>{t("cart.secureStripe", "Secure checkout powered by Stripe")}</span>
+                </div>
+              </div>
 
               <button
                 onClick={handleStripeCheckout}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -95,8 +95,8 @@ const Cart = () => {
         <h1 className="text-2xl font-bold mb-6">{t("cart.title")}</h1>
 
         {cartItems.length === 0 ? (
-          <div className="text-center text-gray-500">
-            <FaRegFrown className="mx-auto mb-4 text-6xl" />
+          <div className="text-center text-gray-900 bg-white border border-gray-200 rounded-lg shadow-sm p-6">
+            <FaRegFrown className="mx-auto mb-4 text-6xl text-gray-500" />
             <p>{t("cart.emptyMessage")}</p>
             <table className="min-w-full border mt-6">
               <thead>
@@ -110,7 +110,7 @@ const Cart = () => {
               </thead>
               <tbody>
                 <tr>
-                  <td className="p-3 text-center text-gray-400" colSpan={5}>
+                  <td className="p-3 text-center text-gray-500" colSpan={5}>
                     {t("cart.noItems")}
                   </td>
                 </tr>
@@ -118,10 +118,20 @@ const Cart = () => {
             </table>
           </div>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto bg-white border border-gray-200 rounded-lg shadow-sm p-6 text-gray-900">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">{t("cart.itemsSection")}</h2>
+              <div className="flex items-center gap-2 text-sm text-gray-700">
+                <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 text-indigo-700 font-semibold border border-indigo-100">
+                  Stripe
+                </span>
+                <span>{t("cart.secureStripe", "Secure checkout powered by Stripe")}</span>
+              </div>
+            </div>
+
             <table className="min-w-full border">
               <thead>
-                <tr className="bg-gray-100 text-left">
+                <tr className="bg-gray-100 text-left text-gray-900">
                   <th className="p-3 border-b">{t("cart.image")}</th>
                   <th className="p-3 border-b">{t("cart.product")}</th>
                   <th className="p-3 border-b">{t("cart.unitPrice")}</th>
@@ -131,7 +141,7 @@ const Cart = () => {
               </thead>
               <tbody>
                 {cartItems.map((item, index) => (
-                  <tr key={item.id ?? index} className="border-t">
+                  <tr key={item.id ?? index} className="border-t text-gray-900">
                     <td className="p-3">
                       <img
                         src={item?.images?.[0]?.src || "/placeholder.svg"}
@@ -161,16 +171,11 @@ const Cart = () => {
             </table>
 
             <div className="flex flex-col sm:flex-row sm:justify-between items-start sm:items-center mt-6 gap-4">
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-1 text-gray-900">
                 <h3 className="text-xl font-semibold">
                   {t("cart.total")}: {calculateTotalItemsPrice()}
                 </h3>
-                <div className="flex items-center gap-2 text-sm text-gray-600">
-                  <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 text-indigo-700 font-semibold border border-indigo-100">
-                    Stripe
-                  </span>
-                  <span>{t("cart.secureStripe", "Secure checkout powered by Stripe")}</span>
-                </div>
+                <span className="text-sm text-gray-700">{t("cart.reviewItems")}</span>
               </div>
 
               <button

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,14 +1,20 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useMyStore } from "@/MyStoreContext";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
+import { DEFAULT_CURRENCY, formatMoney, getCurrencyInfo } from "@/utils/currency";
 
 const Checkout: React.FC = () => {
   const { cart, loggedInUserData } = useMyStore();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+
+  const summaryCurrency = useMemo(
+    () => (cart.length ? getCurrencyInfo(cart[0]) : DEFAULT_CURRENCY),
+    [cart]
+  );
 
   const handleCheckout = async () => {
     if (!cart.length) return toast.error(t("checkout.emptyCart"));
@@ -80,25 +86,26 @@ const Checkout: React.FC = () => {
                 const price =
                   parseFloat(item.sale_price || item.regular_price || item.price || "0") *
                   (item.quantity || 1);
+                const currency = getCurrencyInfo(item);
                 return (
                   <li key={item.id} className="py-2 flex justify-between">
                     <span>{item.name} ({item.quantity || 1})</span>
-                    <span>€{price.toFixed(2)}</span>
+                    <span>{formatMoney(price, currency)}</span>
                   </li>
                 );
               })}
             </ul>
             <div className="mt-4 font-bold text-right">
-              {t("checkout.total")}: €
-              {cart
-                .reduce(
+              {t("checkout.total")}: {formatMoney(
+                cart.reduce(
                   (total, item) =>
                     total +
                     parseFloat(item.sale_price || item.regular_price || item.price || "0") *
                       (item.quantity || 1),
                   0
-                )
-                .toFixed(2)}
+                ),
+                summaryCurrency
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Link, useNavigate } from "react-router-dom";
 import { HOMEPAGE_CATEGORY_IMAGE, KNOWN_CATEGORIES } from "@/constants/categories";
+import { useProductSuggestions } from "@/hooks/useProductSuggestions";
+import { FaRegFrown } from "react-icons/fa";
 
 const socialLinks = [
   { name: "Facebook", icon: <Facebook className="h-5 w-5" />, url: "https://www.facebook.com/profile.php?id=100027587995370" },
@@ -21,6 +23,7 @@ const Index = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState("");
+  const { suggestions, loading, hasNoResults } = useProductSuggestions(searchTerm);
 
   const categories = KNOWN_CATEGORIES.map((category) => ({
     id: category.slug,
@@ -36,19 +39,61 @@ const Index = () => {
     navigate(trimmedTerm ? `/products?search=${encodeURIComponent(trimmedTerm)}` : "/products");
   };
 
+  const handleSuggestionClick = (term: string) => {
+    setSearchTerm(term);
+    navigate(`/products?search=${encodeURIComponent(term)}`);
+  };
+
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar />
       <div className="bg-white shadow-sm">
         <div className="container mx-auto px-4 py-4">
-          <form onSubmit={handleSearch} className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
-            <Input
-              type="search"
-              value={searchTerm}
-              onChange={(event) => setSearchTerm(event.target.value)}
-              placeholder={t("products.search") || "Search products..."}
-              className="flex-1"
-            />
+          <form onSubmit={handleSearch} className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4 relative">
+            <div className="relative flex-1">
+              <Input
+                type="search"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder={t("products.search") || "Search products..."}
+                className="w-full"
+              />
+
+              {(loading || suggestions.length > 0 || hasNoResults) && (
+                <div className="absolute left-0 right-0 mt-1 bg-white border rounded-lg shadow-lg z-20 max-h-64 overflow-y-auto">
+                  {loading && (
+                    <div className="px-3 py-2 text-sm text-gray-500">{t("products.loading", "Loading products...")}</div>
+                  )}
+
+                  {!loading && suggestions.length > 0 && (
+                    <ul className="divide-y">
+                      {suggestions.map((suggestion) => (
+                        <li key={suggestion.id}>
+                          <button
+                            type="button"
+                            onClick={() => handleSuggestionClick(suggestion.name)}
+                            className="w-full text-left px-3 py-2 hover:bg-gray-100"
+                          >
+                            <div className="font-semibold">{suggestion.name}</div>
+                            {suggestion.price && (
+                              <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
+                            )}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  {hasNoResults && (
+                    <div className="px-3 py-4 text-sm text-gray-500 flex items-center gap-2">
+                      <FaRegFrown className="text-xl" />
+                      <span>{t("products.noResults", "No products match your search.")}</span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             <Button type="submit" className="md:w-auto w-full">
               {t("products.search") || "Search products"}
             </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -36,12 +36,31 @@ const Index = () => {
     event.preventDefault();
     const trimmedTerm = searchTerm.trim();
 
+    const categoryMatch = trimmedTerm ? findMatchingCategory(trimmedTerm) : null;
+
+    if (categoryMatch) {
+      navigate(`/categories?category=${encodeURIComponent(categoryMatch.slug)}`);
+      return;
+    }
+
     navigate(trimmedTerm ? `/products?search=${encodeURIComponent(trimmedTerm)}` : "/products");
   };
 
-  const handleSuggestionClick = (term: string) => {
-    setSearchTerm(term);
-    navigate(`/products?search=${encodeURIComponent(term)}`);
+  const handleSuggestionClick = (suggestion: { name: string; type: "product" | "category"; slug?: string }) => {
+    setSearchTerm(suggestion.name);
+
+    if (suggestion.type === "category" && suggestion.slug) {
+      navigate(`/categories?category=${encodeURIComponent(suggestion.slug)}`);
+      return;
+    }
+
+    navigate(`/products?search=${encodeURIComponent(suggestion.name)}`);
+  };
+
+  const findMatchingCategory = (term: string) => {
+    const normalized = term.toLowerCase();
+    return KNOWN_CATEGORIES.find((category) => category.name.toLowerCase() === normalized)
+      || KNOWN_CATEGORIES.find((category) => category.name.toLowerCase().includes(normalized));
   };
 
   return (
@@ -71,13 +90,20 @@ const Index = () => {
                         <li key={suggestion.id}>
                           <button
                             type="button"
-                            onClick={() => handleSuggestionClick(suggestion.name)}
+                            onClick={() => handleSuggestionClick(suggestion)}
                             className="w-full text-left px-3 py-2 hover:bg-gray-100"
                           >
-                            <div className="font-semibold">{suggestion.name}</div>
-                            {suggestion.price && (
-                              <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
-                            )}
+                            <div className="flex items-center justify-between gap-2">
+                              <div>
+                                <div className="font-semibold">{suggestion.name}</div>
+                                {suggestion.price && (
+                                  <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
+                                )}
+                              </div>
+                              {suggestion.type === "category" && (
+                                <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">Kategória</span>
+                              )}
+                            </div>
                           </button>
                         </li>
                       ))}
@@ -104,10 +130,10 @@ const Index = () => {
 
       {/* Promo Section */}
       <section className="container py-16 bg-background w-full max-w-4xl mx-auto">
-        <h2 className="text-4xl font-bold mb-8 text-center">{t("promo.title", "Miért a Hangakadémia®?")}</h2>
+        <h2 className="text-4xl font-bold mb-8 text-center">{t("promo.title", "Miért a HangAkadémia®?")}</h2>
         <div className="mb-8 text-lg text-gray-700 space-y-2 leading-relaxed">
           <p>{t("promo.benefit1", "Prémium minőségű, gondosan válogatott hangszerek – szakmai háttérrel.")}</p>
-          <p>{t("promo.background1", "A Hangakadémia® nem csupán egy webshop.")}</p>
+          <p>{t("promo.background1", "A HangAkadémia® nem csupán egy webshop.")}</p>
           <p>
             {t(
               "promo.background2",
@@ -117,7 +143,7 @@ const Index = () => {
           <p>
             {t(
               "promo.partnership",
-              "A Hangakadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete."
+              "A HangAkadémia® a Meinl Sonic Energy hivatalos szakmai partnere, alapítója, Pál Adrienn, Magyarország hivatalos Meinl Sonic Energy szakmai nagykövete."
             )}
           </p>
           <p>{t("promo.value", "Nálunk nem csak eszközt vásárolsz – útmutatást, tudást és megbízható szakmai hátteret is kapsz.")}</p>
@@ -125,7 +151,7 @@ const Index = () => {
         <div className="text-center">
           <Link to="https://hangakademia.hu" target="_blank" rel="noopener noreferrer">
             <button className="bg-primary text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-primary/90 transition">
-              {t("promo.cta", "👉 Ismerd meg a Hangakadémiát® és a Meinl Sonic Energy Magyarországi Nagykövetét")}
+              {t("promo.cta", "👉 Ismerd meg a HangAkadémiát® és a Meinl Sonic Energy Magyarországi Nagykövetét")}
             </button>
           </Link>
           {/* Guarantees */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import { FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Navbar } from "@/components/Navbar";
 import { Hero } from "@/components/Hero";
@@ -5,7 +6,8 @@ import { CategoryCard } from "@/components/CategoryCard";
 import { Footer } from "@/components/Footer";
 import { Facebook, Instagram, Music2, Youtube } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Link, useNavigate } from "react-router-dom";
 import { HOMEPAGE_CATEGORY_IMAGE, KNOWN_CATEGORIES } from "@/constants/categories";
 
 const socialLinks = [
@@ -17,6 +19,8 @@ const socialLinks = [
 
 const Index = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState("");
 
   const categories = KNOWN_CATEGORIES.map((category) => ({
     id: category.slug,
@@ -25,9 +29,32 @@ const Index = () => {
     image: category.image || HOMEPAGE_CATEGORY_IMAGE,
   }));
 
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTerm = searchTerm.trim();
+
+    navigate(trimmedTerm ? `/products?search=${encodeURIComponent(trimmedTerm)}` : "/products");
+  };
+
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Navbar />
+      <div className="bg-white shadow-sm">
+        <div className="container mx-auto px-4 py-4">
+          <form onSubmit={handleSearch} className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
+            <Input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder={t("products.search") || "Search products..."}
+              className="flex-1"
+            />
+            <Button type="submit" className="md:w-auto w-full">
+              {t("products.search") || "Search products"}
+            </Button>
+          </form>
+        </div>
+      </div>
       <Hero />
 
       {/* Promo Section */}

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -1,17 +1,19 @@
 import { useNavigate, useLocation } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CheckCircle } from "lucide-react";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { useTranslation } from "react-i18next";
+import { formatMoney, getCurrencyInfo } from "@/utils/currency";
 
 const PaymentSuccess = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const [totalAmount, setTotalAmount] = useState<string | null>(null);
+  const [totalAmount, setTotalAmount] = useState<number | null>(null);
+  const [currencyCode, setCurrencyCode] = useState<string>("HUF");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,7 +33,10 @@ const PaymentSuccess = () => {
         }
         const data = await res.json();
         if (data.amount_total) {
-          setTotalAmount((data.amount_total / 100).toFixed(2));
+          setTotalAmount(data.amount_total / 100);
+          if (data.currency) {
+            setCurrencyCode(String(data.currency).toUpperCase());
+          }
         } else {
           throw new Error("No amount_total in session");
         }
@@ -49,6 +54,11 @@ const PaymentSuccess = () => {
       setLoading(false);
     }
   }, [sessionId, t]);
+
+  const currencyInfo = useMemo(
+    () => getCurrencyInfo({ currency: currencyCode, currency_symbol: undefined }),
+    [currencyCode]
+  );
 
   if (loading) return <div className="text-center mt-10">{t("paymentSuccess.loading", "Loading...")}</div>;
   if (error) return <div className="text-center text-red-500 mt-10">{error}</div>;
@@ -73,7 +83,9 @@ const PaymentSuccess = () => {
             </p>
             <div className="bg-gray-50 p-4 rounded-lg">
               <p className="font-semibold">
-                {t("paymentSuccess.amountPaid", "Fizetett összeg")}: {totalAmount} €
+                {t("paymentSuccess.amountPaid", "Fizetett összeg")}: {totalAmount !== null
+                  ? formatMoney(totalAmount, currencyInfo)
+                  : ""}
               </p>
             </div>
             <div className="space-y-2">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { CATEGORY_ORDER_MAP, KNOWN_CATEGORIES } from "@/constants/categories";
 import { FaRegFrown } from "react-icons/fa";
 import { useProductSuggestions } from "@/hooks/useProductSuggestions";
+import { getCurrencyInfo } from "@/utils/currency";
 
 interface Product {
   id: number;
@@ -16,6 +17,7 @@ interface Product {
   featured?: boolean;
   regular_price?: string;
   sale_price?: string;
+  price_html?: string;
   description?: string;
   short_description?: string;
   stock_status?: string;
@@ -24,6 +26,10 @@ interface Product {
   attributes?: { id: number; name: string; options: string[] }[];
   date_created?: string;
   total_sales?: number;
+  currency?: string;
+  currency_symbol?: string;
+  currency_code?: string;
+  prices?: { currency_code?: string; currency_symbol?: string };
   meta_data?: { key: string; value: string }[];
 }
 
@@ -307,8 +313,18 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
           })
         );
 
-        setProducts(updatedData);
-        setCache(PRODUCT_CACHE_KEY, updatedData);
+        const normalizedProducts = updatedData.map((product) => {
+          const currency = getCurrencyInfo(product);
+          return {
+            ...product,
+            currency: product.currency || currency.code,
+            currency_symbol: product.currency_symbol || currency.symbol,
+            prices: product.prices || { currency_code: currency.code, currency_symbol: currency.symbol },
+          };
+        });
+
+        setProducts(normalizedProducts);
+        setCache(PRODUCT_CACHE_KEY, normalizedProducts);
         setLoading(false);
         setPageLoading(false);
       } catch (err) {
@@ -588,18 +604,22 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
                   <p>{t("products.noResults", "No products match your search.")}</p>
                 </div>
               ) : (
-                filteredProducts.slice(0, visibleCount).map((product) => (
-                  <ProductCard
-                    key={product.id}
-                    title={product.name}
-                    price={parseFloat(product.price)}
-                    image={product.images?.[0]?.src || "/placeholder.jpg"}
-                    available={product.stock_status === "instock"}
-                    id={String(product.id)}
-                    description={product.short_description || product.description}
-                    onAddToCart={() => onAddToCart(product)}
-                  />
-                ))
+                filteredProducts.slice(0, visibleCount).map((product) => {
+                  const currency = getCurrencyInfo(product);
+                  return (
+                    <ProductCard
+                      key={product.id}
+                      title={product.name}
+                      price={parseFloat(product.price)}
+                      image={product.images?.[0]?.src || "/placeholder.jpg"}
+                      available={product.stock_status === "instock"}
+                      id={String(product.id)}
+                      description={product.short_description || product.description}
+                      onAddToCart={() => onAddToCart(product)}
+                      currency={currency}
+                    />
+                  );
+                })
               )}
             </div>
 

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -4,6 +4,7 @@ import { Footer } from "@/components/Footer";
 import { ProductCard } from "@/components/ProductCard";
 import { useTranslation } from "react-i18next";
 import { CATEGORY_ORDER_MAP, KNOWN_CATEGORIES } from "@/constants/categories";
+import { FaRegFrown } from "react-icons/fa";
 
 interface Product {
   id: number;
@@ -202,6 +203,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     async <T,>(endpoint: string) => {
       const allItems: T[] = [];
       let page = 1;
+      let totalPages: number | null = null;
       while (true) {
         const res = await fetch(`${apiUrl}/${endpoint}?per_page=100&page=${page}`, {
           headers: { Authorization: `Basic ${auth}` },
@@ -211,7 +213,16 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
         }
         const pageData: T[] = await res.json();
         allItems.push(...pageData);
-        if (pageData.length < 100) break;
+
+        if (totalPages === null) {
+          const headerPages = res.headers.get("X-WP-TotalPages");
+          totalPages = headerPages ? parseInt(headerPages, 10) || null : null;
+        }
+
+        const reachedLastPage =
+          (totalPages !== null && page >= totalPages) || pageData.length < 100;
+
+        if (reachedLastPage) break;
         page += 1;
       }
       return allItems;
@@ -519,18 +530,25 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
                 viewMode === "grid" ? "grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" : "grid-cols-1"
               } p-1`}
             >
-              {filteredProducts.slice(0, visibleCount).map((product) => (
-                <ProductCard
-                  key={product.id}
-                  title={product.name}
-                  price={parseFloat(product.price)}
-                  image={product.images?.[0]?.src || "/placeholder.jpg"}
-                  available={product.stock_status === "instock"}
-                  id={String(product.id)}
-                  description={product.short_description || product.description}
-                  onAddToCart={() => onAddToCart(product)}
-                />
-              ))}
+              {filteredProducts.length === 0 ? (
+                <div className="col-span-full text-center text-gray-500 py-12 flex flex-col items-center gap-3">
+                  <FaRegFrown className="text-5xl" />
+                  <p>{t("products.noResults", "No products match your search.")}</p>
+                </div>
+              ) : (
+                filteredProducts.slice(0, visibleCount).map((product) => (
+                  <ProductCard
+                    key={product.id}
+                    title={product.name}
+                    price={parseFloat(product.price)}
+                    image={product.images?.[0]?.src || "/placeholder.jpg"}
+                    available={product.stock_status === "instock"}
+                    id={String(product.id)}
+                    description={product.short_description || product.description}
+                    onAddToCart={() => onAddToCart(product)}
+                  />
+                ))
+              )}
             </div>
 
             {/* Load More Button */}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -480,13 +480,25 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
                           <li key={suggestion.id}>
                             <button
                               type="button"
-                              onClick={() => setSearchTerm(suggestion.name)}
+                              onClick={() => {
+                                setSearchTerm(suggestion.name);
+                                if (suggestion.type === "category" && suggestion.slug) {
+                                  setSelectedCategory(suggestion.slug);
+                                }
+                              }}
                               className="w-full text-left px-3 py-2 hover:bg-gray-100"
                             >
-                              <div className="font-semibold">{suggestion.name}</div>
-                              {suggestion.price && (
-                                <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
-                              )}
+                              <div className="flex items-center justify-between gap-2">
+                                <div>
+                                  <div className="font-semibold">{suggestion.name}</div>
+                                  {suggestion.price && (
+                                    <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
+                                  )}
+                                </div>
+                                {suggestion.type === "category" && (
+                                  <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">Kategória</span>
+                                )}
+                              </div>
                             </button>
                           </li>
                         ))}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -5,6 +5,7 @@ import { ProductCard } from "@/components/ProductCard";
 import { useTranslation } from "react-i18next";
 import { CATEGORY_ORDER_MAP, KNOWN_CATEGORIES } from "@/constants/categories";
 import { FaRegFrown } from "react-icons/fa";
+import { useProductSuggestions } from "@/hooks/useProductSuggestions";
 
 interface Product {
   id: number;
@@ -95,6 +96,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
   const [error, setError] = useState("");
   const [categories, setCategories] = useState<{ key: string; label: string }[]>([]);
   const [visibleCount, setVisibleCount] = useState(VISIBLE_INCREMENT);
+  const { suggestions, loading: suggestionsLoading, hasNoResults: suggestionNone } = useProductSuggestions(searchTerm);
 
   // priceRanges depends on i18n (t), so memoize it to avoid recreating each render
   const priceRanges: PriceRange[] = useMemo(
@@ -455,13 +457,51 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
           {/* Sidebar Filters */}
           <div className="w-full md:w-64 flex-shrink-0">
             <div className="flex flex-col gap-4">
-              <input
-                type="text"
-                placeholder={t("products.search") || "Search products..."}
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="border px-3 py-2 rounded w-full"
-              />
+              <div className="relative">
+                <input
+                  type="text"
+                  placeholder={t("products.search") || "Search products..."}
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="border px-3 py-2 rounded w-full"
+                />
+
+                {(suggestionsLoading || suggestions.length > 0 || suggestionNone) && (
+                  <div className="absolute left-0 right-0 mt-1 bg-white border rounded-lg shadow-lg z-30 max-h-64 overflow-y-auto">
+                    {suggestionsLoading && (
+                      <div className="px-3 py-2 text-sm text-gray-500">
+                        {t("products.loading", "Loading products...")}
+                      </div>
+                    )}
+
+                    {!suggestionsLoading && suggestions.length > 0 && (
+                      <ul className="divide-y">
+                        {suggestions.map((suggestion) => (
+                          <li key={suggestion.id}>
+                            <button
+                              type="button"
+                              onClick={() => setSearchTerm(suggestion.name)}
+                              className="w-full text-left px-3 py-2 hover:bg-gray-100"
+                            >
+                              <div className="font-semibold">{suggestion.name}</div>
+                              {suggestion.price && (
+                                <div className="text-sm text-gray-500">{suggestion.price} Ft</div>
+                              )}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {suggestionNone && (
+                      <div className="px-3 py-4 text-sm text-gray-500 flex items-center gap-2">
+                        <FaRegFrown className="text-xl" />
+                        <span>{t("products.noResults", "No products match your search.")}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
 
               <select
                 value={selectedCategory}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -184,6 +184,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const urlCategory = params.get("category");
+    const urlSearch = params.get("search");
     if (urlCategory) {
       setSelectedCategory(urlCategory);
     } else if (defaultCategory) {
@@ -191,7 +192,32 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
       params.set("category", defaultCategory);
       window.history.replaceState({}, "", `${window.location.pathname}?${params}`);
     }
+
+    if (urlSearch) {
+      setSearchTerm(urlSearch);
+    }
   }, [defaultCategory]);
+
+  const fetchPaginated = useCallback(
+    async <T,>(endpoint: string) => {
+      const allItems: T[] = [];
+      let page = 1;
+      while (true) {
+        const res = await fetch(`${apiUrl}/${endpoint}?per_page=100&page=${page}`, {
+          headers: { Authorization: `Basic ${auth}` },
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to fetch ${endpoint} page ${page}`);
+        }
+        const pageData: T[] = await res.json();
+        allItems.push(...pageData);
+        if (pageData.length < 100) break;
+        page += 1;
+      }
+      return allItems;
+    },
+    [apiUrl, auth]
+  );
 
   // Fetch categories
   useEffect(() => {
@@ -211,11 +237,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
           );
         }
 
-        const res = await fetch(`${apiUrl}/products/categories`, {
-          headers: { Authorization: `Basic ${auth}` },
-        });
-
-        const data: ProductCategory[] = await res.json();
+        const data = await fetchPaginated<ProductCategory>("products/categories");
 
         setCategories(
           sortCategoriesByOrder([
@@ -234,7 +256,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     };
 
     fetchCategories();
-  }, [apiUrl, auth, knownCategoryBySlug, sortCategoriesByOrder, t]);
+  }, [fetchPaginated, knownCategoryBySlug, sortCategoriesByOrder, t]);
 
   // Fetch products
   useEffect(() => {
@@ -248,12 +270,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
           setLoading(false);
         }
 
-        const res = await fetch(`${apiUrl}/products?per_page=100`, {
-          headers: { Authorization: `Basic ${auth}`, "Content-Type": "application/json" },
-        });
-        if (!res.ok) throw new Error("Failed to fetch products");
-
-        const data: Product[] = await res.json();
+        const data = await fetchPaginated<Product>("products");
 
         const updatedData = await Promise.all(
           data.map(async (product) => {
@@ -290,7 +307,7 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
     };
 
     fetchProducts();
-  }, [apiUrl, auth, setPageLoading, t]);
+  }, [apiUrl, auth, fetchPaginated, setPageLoading, t]);
 
   // Filtering logic
   useEffect(() => {
@@ -298,9 +315,11 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
 
     const filtered = products
       .filter((product) => {
+        const searchTermLower = searchTerm.toLowerCase();
         const matchesSearch =
-          product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          (product.description || "").toLowerCase().includes(searchTerm.toLowerCase());
+          product.name.toLowerCase().includes(searchTermLower) ||
+          (product.description || "").toLowerCase().includes(searchTermLower) ||
+          product.categories?.some((c) => c.name.toLowerCase().includes(searchTermLower));
 
         const matchesCategory =
           selectedCategory === "all" || product.categories?.some((c) => c.slug === selectedCategory);
@@ -358,12 +377,18 @@ const Products = ({ onAddToCart, setPageLoading, defaultCategory }: ProductsProp
 
     setFilteredProducts(filtered);
 
-    // Update URL when category changes
+    // Update URL when category or search changes
     const params = new URLSearchParams(window.location.search);
     if (selectedCategory && selectedCategory !== "all") {
       params.set("category", selectedCategory);
     } else {
       params.delete("category");
+    }
+
+    if (searchTerm) {
+      params.set("search", searchTerm);
+    } else {
+      params.delete("search");
     }
     window.history.replaceState({}, "", `${window.location.pathname}?${params}`);
   }, [

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,80 @@
+export interface CurrencySource {
+  currency?: string;
+  currency_code?: string;
+  currency_symbol?: string;
+  prices?: { currency_code?: string; currency_symbol?: string };
+  meta_data?: { key: string; value: unknown }[];
+  price_html?: string;
+}
+
+export interface CurrencyInfo {
+  code: string;
+  symbol: string;
+}
+
+const DEFAULT_CURRENCY: CurrencyInfo = { code: "HUF", symbol: "Ft" };
+
+const META_CURRENCY_KEYS = ["currency", "_currency", "_order_currency", "current_currency"];
+
+const extractSymbolFromHtml = (priceHtml?: string): string | undefined => {
+  if (!priceHtml) return undefined;
+  const stripped = priceHtml.replace(/<[^>]+>/g, " ");
+  const match = stripped.match(/([^\d.,\s]+)/);
+  return match?.[1]?.trim() || undefined;
+};
+
+const getIntlSymbol = (code: string): string | undefined => {
+  try {
+    const parts = new Intl.NumberFormat("hu-HU", {
+      style: "currency",
+      currency: code,
+      minimumFractionDigits: 2,
+    }).formatToParts(0);
+    return parts.find((p) => p.type === "currency")?.value;
+  } catch {
+    return undefined;
+  }
+};
+
+export const getCurrencyInfo = (source?: CurrencySource | null): CurrencyInfo => {
+  if (!source) return DEFAULT_CURRENCY;
+
+  const metaCurrency = source.meta_data?.find((meta) => META_CURRENCY_KEYS.includes(meta.key))?.value;
+  const metaCurrencyCode = typeof metaCurrency === "string" ? metaCurrency : undefined;
+  const explicitSymbol =
+    source.currency_symbol ||
+    source.prices?.currency_symbol ||
+    (typeof metaCurrency === "object" && metaCurrency !== null && "symbol" in (metaCurrency as Record<string, unknown>)
+      ? String((metaCurrency as Record<string, unknown>).symbol)
+      : undefined);
+
+  const code =
+    source.currency ||
+    source.currency_code ||
+    source.prices?.currency_code ||
+    metaCurrencyCode ||
+    DEFAULT_CURRENCY.code;
+
+  const symbol =
+    explicitSymbol ||
+    extractSymbolFromHtml(source.price_html) ||
+    getIntlSymbol(code) ||
+    DEFAULT_CURRENCY.symbol;
+
+  return { code, symbol };
+};
+
+export const formatMoney = (amount: number, currency: CurrencyInfo): string => {
+  if (!Number.isFinite(amount)) return `${currency.symbol} 0.00`;
+  try {
+    return new Intl.NumberFormat("hu-HU", {
+      style: "currency",
+      currency: currency.code,
+      minimumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency.symbol || currency.code}`;
+  }
+};
+
+export { DEFAULT_CURRENCY };


### PR DESCRIPTION
## Summary
- add shared paginated fetcher to pull all WooCommerce products and categories from the REST API
- use full product/category lists to keep search in sync with WordPress data and match category names in queries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949aa079b4c833288cee6ebdc8be18a)